### PR TITLE
feat: add express server with firebase admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "test": "jest --watchAll",
     "build": "echo \"Dry build complete\"",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "server": "npm --prefix server start"
   },
   "jest": {
     "preset": "jest-expo"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+serviceAccount.json

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const admin = require('firebase-admin');
+
+// Load service account from environment variable
+let serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!serviceAccount) {
+  throw new Error('FIREBASE_SERVICE_ACCOUNT env var not set');
+}
+try {
+  serviceAccount = JSON.parse(serviceAccount);
+} catch (err) {
+  throw new Error('FIREBASE_SERVICE_ACCOUNT must be valid JSON');
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+});
+
+const auth = admin.auth();
+const db = admin.firestore();
+
+const app = express();
+app.use(express.json());
+
+// Example auth endpoint: create custom token for a user
+app.post('/auth/token', async (req, res) => {
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ error: 'uid is required' });
+  }
+  try {
+    const token = await auth.createCustomToken(uid);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Example Firestore endpoint: get user document
+app.get('/users/:id', async (req, res) => {
+  try {
+    const doc = await db.collection('users').doc(req.params.id).get();
+    if (!doc.exists) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.json(doc.data());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+
+module.exports = app;

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "datingapp-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "firebase-admin": "^12.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Express server
- load Firebase service account from env var
- add auth and Firestore endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e719b470832db2389aaaa2db9055