### PR TITLE
Add users API endpoint and client service

### DIFF
--- a/app/(tabs)/home/homeScreen.js
+++ b/app/(tabs)/home/homeScreen.js
@@ -9,27 +9,45 @@ import {
 import React, { useState, useRef, useEffect } from 'react'
 import { Colors, Fonts, screenHeight, screenWidth, Sizes } from '../../../constants/styles'
 import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons'
-import { usersList } from '../../../components/usersList'
 import { useNavigation } from 'expo-router'
 import TinderCard from 'react-tinder-card'
 import { LinearGradient } from 'expo-linear-gradient'
+import { fetchUsers } from '../../../services/userService'
 
 const HomeScreen = () => {
 
     const navigation = useNavigation();
 
-    const [users, setusers] = useState(usersList)
+    const [users, setusers] = useState([])
     const [search, setsearch] = useState('');
     const searchFieldRef = useRef(null);
-    const [cardLength, setCardLength] = useState(usersList.length);
+    const [cardLength, setCardLength] = useState(0);
 
     useEffect(() => {
-        if (cardLength == 0) {
-            setCardLength(14);
-            setusers(usersList);
+        (async () => {
+            try {
+                const data = await fetchUsers();
+                setusers(data);
+                setCardLength(data.length);
+            } catch (error) {
+                console.error(error);
+            }
+        })();
+    }, []);
+
+    useEffect(() => {
+        if (cardLength === 0) {
+            (async () => {
+                try {
+                    const data = await fetchUsers();
+                    setusers(data);
+                    setCardLength(data.length);
+                } catch (error) {
+                    console.error(error);
+                }
+            })();
         }
-        return () => { }
-    }, [cardLength])
+    }, [cardLength]);
 
     return (
         <View style={{ flex: 1, backgroundColor: Colors.whiteColor, }}>

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,17 @@ app.post('/auth/token', async (req, res) => {
   }
 });
 
+// Get all users
+app.get('/users', async (req, res) => {
+  try {
+    const snapshot = await db.collection('users').get();
+    const users = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Example Firestore endpoint: get user document
 app.get('/users/:id', async (req, res) => {
   try {

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,0 +1,13 @@
+export async function fetchUsers() {
+  const baseUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (!baseUrl) {
+    throw new Error('EXPO_PUBLIC_API_URL not set');
+  }
+
+  const response = await fetch(`${baseUrl}/users`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch users');
+  }
+  return response.json();
+}
+


### PR DESCRIPTION
## Summary
- add `/users` endpoint to return all user profiles
- create `fetchUsers` client service using `EXPO_PUBLIC_API_URL`
- load user profiles in HomeScreen from API instead of static list

## Testing
- `npm test`
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc9143ab4832dab80d0e1340de0fa