### PR TITLE
feat: add contact endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ The backend server lives in the `server` directory.
    npm start
    ```
 
+### API Endpoints
+
+- `POST /contact` – submit a contact form message. Send a JSON body with `name`, `email`, and `message` fields. On success the server responds with `{ "success": true }`.
+
 ## Get a fresh project
 
 When you're ready, run:

--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View, ScrollView, Image, TextInput, TouchableOpacity } from 'react-native'
+import { StyleSheet, Text, View, ScrollView, Image, TextInput, TouchableOpacity, Alert } from 'react-native'
 import React, { useState } from 'react'
 import { Colors, Fonts, screenWidth, Sizes, CommonStyles } from '../../constants/styles'
 import MyStatusBar from '../../components/myStatusBar';
@@ -16,18 +16,28 @@ const ContactUsScreen = () => {
     const [message, setmessage] = useState('');
 
     const handleSend = async () => {
-        if (apiUrl) {
-            try {
-                await fetch(`${apiUrl}/contact`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, email, message }),
-                });
-            } catch (error) {
-                console.error('Failed to send contact request', error);
-            }
+        if (!apiUrl) {
+            Alert.alert('Error', 'API URL is not configured');
+            return;
         }
-        navigation.pop();
+
+        try {
+            const response = await fetch(`${apiUrl}/contact`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, email, message }),
+            });
+
+            if (response.ok) {
+                Alert.alert('Success', 'Message sent successfully');
+                navigation.pop();
+            } else {
+                Alert.alert('Error', 'Failed to send message');
+            }
+        } catch (error) {
+            console.error('Failed to send contact request', error);
+            Alert.alert('Error', 'Failed to send message');
+        }
     };
 
     return (

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,26 @@ const db = admin.firestore();
 const app = express();
 app.use(express.json());
 
+// Contact form endpoint
+app.post('/contact', async (req, res) => {
+  const { name, email, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'name, email, and message are required' });
+  }
+  try {
+    await db.collection('contactMessages').add({
+      name,
+      email,
+      message,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to save contact message', err);
+    res.status(500).json({ error: 'Failed to save message' });
+  }
+});
+
 // Example auth endpoint: create custom token for a user
 app.post('/auth/token', async (req, res) => {
   const { uid } = req.body;


### PR DESCRIPTION
## Summary
- handle POST /contact requests and store messages in Firestore
- notify users of contact form success or failure
- document the contact endpoint in the server README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfea842bd0832d87e5910649a044d2