### PR TITLE
feat: add fetchJson error handler

### DIFF
--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -1,8 +1,9 @@
-import { StyleSheet, Text, View, ScrollView, Image, TextInput, TouchableOpacity } from 'react-native'
+import { StyleSheet, Text, View, ScrollView, Image, TextInput, TouchableOpacity, Alert } from 'react-native'
 import React, { useState } from 'react'
 import { Colors, Fonts, screenWidth, Sizes, CommonStyles } from '../../constants/styles'
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation } from 'expo-router';
+import { fetchJson } from '../../services/api';
 
 const ContactUsScreen = () => {
 
@@ -16,18 +17,21 @@ const ContactUsScreen = () => {
     const [message, setmessage] = useState('');
 
     const handleSend = async () => {
-        if (apiUrl) {
-            try {
-                await fetch(`${apiUrl}/contact`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, email, message }),
-                });
-            } catch (error) {
-                console.error('Failed to send contact request', error);
-            }
+        if (!apiUrl) {
+            Alert.alert('Error', 'API URL not set');
+            return;
         }
-        navigation.pop();
+
+        try {
+            await fetchJson(`${apiUrl}/contact`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, email, message }),
+            });
+            navigation.pop();
+        } catch (error) {
+            // Error handled in fetchJson
+        }
     };
 
     return (

--- a/services/api.js
+++ b/services/api.js
@@ -1,0 +1,16 @@
+import { Alert } from 'react-native';
+
+export async function fetchJson(url, options) {
+  try {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const message = `Request failed with status ${response.status}`;
+      Alert.alert('Error', message);
+      throw new Error(message);
+    }
+    return await response.json();
+  } catch (error) {
+    Alert.alert('Error', error.message);
+    throw error;
+  }
+}

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,13 +1,11 @@
+import { fetchJson } from './api';
+
 export async function fetchUsers() {
   const baseUrl = process.env.EXPO_PUBLIC_API_URL;
   if (!baseUrl) {
     throw new Error('EXPO_PUBLIC_API_URL not set');
   }
 
-  const response = await fetch(`${baseUrl}/users`);
-  if (!response.ok) {
-    throw new Error('Failed to fetch users');
-  }
-  return response.json();
+  return fetchJson(`${baseUrl}/users`);
 }
 


### PR DESCRIPTION
## Summary
- add shared fetchJson helper that alerts on API errors
- use fetchJson in contact form submit
- apply fetchJson to user service fetching users

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfea8dae34832da83358497e142500