### PR TITLE
Handle API errors with fetchJson wrapper

### DIFF
--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { Colors, Fonts, screenWidth, Sizes, CommonStyles } from '../../constants/styles'
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation } from 'expo-router';
+import { fetchJson } from '../../services/api';
 
 const ContactUsScreen = () => {
 
@@ -21,22 +22,15 @@ const ContactUsScreen = () => {
             return;
         }
 
-        try {
-            const response = await fetch(`${apiUrl}/contact`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name, email, message }),
-            });
+        const response = await fetchJson(`${apiUrl}/contact`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, email, message }),
+        });
 
-            if (response.ok) {
-                Alert.alert('Success', 'Message sent successfully');
-                navigation.pop();
-            } else {
-                Alert.alert('Error', 'Failed to send message');
-            }
-        } catch (error) {
-            console.error('Failed to send contact request', error);
-            Alert.alert('Error', 'Failed to send message');
+        if (response) {
+            Alert.alert('Success', 'Message sent successfully');
+            navigation.pop();
         }
     };
 

--- a/services/api.js
+++ b/services/api.js
@@ -1,0 +1,17 @@
+import { Alert } from 'react-native';
+
+export async function fetchJson(url, options) {
+  try {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const message = `Request failed with status ${response.status}`;
+      Alert.alert('Error', message);
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    Alert.alert('Error', message);
+    return null;
+  }
+}

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,13 +1,13 @@
+import { Alert } from 'react-native';
+import { fetchJson } from './api';
+
 export async function fetchUsers() {
   const baseUrl = process.env.EXPO_PUBLIC_API_URL;
   if (!baseUrl) {
-    throw new Error('EXPO_PUBLIC_API_URL not set');
+    Alert.alert('Error', 'EXPO_PUBLIC_API_URL not set');
+    return null;
   }
 
-  const response = await fetch(`${baseUrl}/users`);
-  if (!response.ok) {
-    throw new Error('Failed to fetch users');
-  }
-  return response.json();
+  return await fetchJson(`${baseUrl}/users`);
 }
 


### PR DESCRIPTION
## Summary
- add fetchJson helper to alert on failed requests
- update ContactUsScreen and user service to use fetchJson

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfec068060832db20c517d5ff19024