### PR TITLE
feat: centralize api fetch helper

### DIFF
--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -8,7 +8,6 @@ import { fetchJson } from '../../services/api';
 const ContactUsScreen = () => {
 
     const navigation = useNavigation();
-    const apiUrl = process.env.EXPO_PUBLIC_API_URL;
     const defaultName = process.env.EXPO_PUBLIC_DEFAULT_NAME || 'Joseph Reese';
     const defaultEmail = process.env.EXPO_PUBLIC_DEFAULT_EMAIL || 'josephreese@gmail.com';
 
@@ -17,12 +16,7 @@ const ContactUsScreen = () => {
     const [message, setmessage] = useState('');
 
     const handleSend = async () => {
-        if (!apiUrl) {
-            Alert.alert('Error', 'API URL is not configured');
-            return;
-        }
-
-        const response = await fetchJson(`${apiUrl}/contact`, {
+        const response = await fetchJson('/contact', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name, email, message }),

--- a/services/api.js
+++ b/services/api.js
@@ -1,6 +1,15 @@
 import { Alert } from 'react-native';
 
-export async function fetchJson(url, options) {
+// TODO: Add auth headers and token refresh logic once authentication is implemented.
+export async function fetchJson(path, options) {
+  const baseUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (!baseUrl) {
+    Alert.alert('Error', 'EXPO_PUBLIC_API_URL not set');
+    return null;
+  }
+
+  const url = `${baseUrl}${path}`;
+
   try {
     const response = await fetch(url, options);
     if (!response.ok) {

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,13 +1,6 @@
-import { Alert } from 'react-native';
 import { fetchJson } from './api';
 
 export async function fetchUsers() {
-  const baseUrl = process.env.EXPO_PUBLIC_API_URL;
-  if (!baseUrl) {
-    Alert.alert('Error', 'EXPO_PUBLIC_API_URL not set');
-    return null;
-  }
-
-  return await fetchJson(`${baseUrl}/users`);
+  return await fetchJson('/users');
 }
 


### PR DESCRIPTION
## Summary
- centralize API requests through fetchJson
- refactor services and contact screen to use helper

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfed843198832db5ae590a3c556c02