### PR TITLE
Add Firestore rules and CI deployment

### DIFF
--- a/.github/workflows/firestore-rules.yml
+++ b/.github/workflows/firestore-rules.yml
@@ -1,0 +1,16 @@
+name: Deploy Firestore Rules
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w9jds/firebase-action@v2.2.0
+        with:
+          args: deploy --only firestore:rules
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/app/auth/loginScreen.js
+++ b/app/auth/loginScreen.js
@@ -45,7 +45,10 @@ const LoginScreen = () => {
     const handleLogin = async () => {
         try {
             const userCredential = await signInWithEmailAndPassword(auth, email, password);
-            const userDoc = await getDoc(doc(db, 'users', userCredential.user.uid));
+            const { uid, email: authEmail } = userCredential.user;
+            const userRef = doc(db, 'users', uid);
+            await setDoc(userRef, { uid, email: authEmail }, { merge: true });
+            const userDoc = await getDoc(userRef);
             if (userDoc.exists()) {
                 setProfile(userDoc.data());
             }
@@ -59,13 +62,19 @@ const LoginScreen = () => {
     const handleRegister = async () => {
         try {
             const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+            const { uid } = userCredential.user;
             const profileData = {
+                uid,
                 name: '',
                 age: 0,
                 email,
             };
-            await setDoc(doc(db, 'users', userCredential.user.uid), profileData);
-            setProfile(profileData);
+            const userRef = doc(db, 'users', uid);
+            await setDoc(userRef, profileData);
+            const userDoc = await getDoc(userRef);
+            if (userDoc.exists()) {
+                setProfile(userDoc.data());
+            }
             Alert.alert('Success', 'Account created successfully');
             navigation.push('(tabs)');
         } catch (error) {

--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -4,7 +4,7 @@ import { Colors, Fonts, screenWidth, Sizes, CommonStyles } from '../../constants
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation } from 'expo-router';
 import { useUser } from '../../context/userContext';
-import { db } from '../../firebaseConfig';
+import { auth, db } from '../../firebaseConfig';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 const ContactUsScreen = () => {
@@ -18,6 +18,10 @@ const ContactUsScreen = () => {
     const [loading, setLoading] = useState(false);
 
     const handleSend = async () => {
+        if (!auth.currentUser) {
+            Alert.alert('Error', 'You must be logged in to send a message');
+            return;
+        }
         setLoading(true);
         try {
             await addDoc(collection(db, 'contactMessages'), {

--- a/app/editProfile/editProfileScreen.js
+++ b/app/editProfile/editProfileScreen.js
@@ -6,6 +6,8 @@ import { Dropdown } from 'react-native-element-dropdown';
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation } from 'expo-router';
 import { useUser } from '../../context/userContext';
+import { auth, db } from '../../firebaseConfig';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
 
 const agesList = [
     { label: '25 Years' },
@@ -64,8 +66,15 @@ const EditProfileScreen = () => {
         return (
             <TouchableOpacity
                 activeOpacity={0.8}
-                onPress={() => {
-                    setProfile({ ...profile, name, age: parseInt(age) });
+                onPress={async () => {
+                    const uid = auth.currentUser?.uid;
+                    if (!uid) return;
+                    const userRef = doc(db, 'users', uid);
+                    await setDoc(userRef, { uid, name, age: parseInt(age), email: profile.email }, { merge: true });
+                    const userDoc = await getDoc(userRef);
+                    if (userDoc.exists()) {
+                        setProfile(userDoc.data());
+                    }
                     navigation.pop();
                 }}
                 style={styles.buttonStyle}

--- a/context/userContext.js
+++ b/context/userContext.js
@@ -1,9 +1,26 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { auth, db } from '../firebaseConfig';
 
 const UserContext = createContext(null);
 
 export const UserProvider = ({ children }) => {
   const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        const userDoc = await getDoc(doc(db, 'users', user.uid));
+        if (userDoc.exists()) {
+          setProfile(userDoc.data());
+        }
+      } else {
+        setProfile(null);
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   return (
     <UserContext.Provider value={{ profile, setProfile }}>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,30 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isValidUser(data, uid) {
+      return data.keys().hasAll(['uid', 'name', 'email']) &&
+             data.uid == uid &&
+             data.name is string &&
+             data.email is string;
+    }
+
+    function isValidContactMessage(data) {
+      return data.keys().hasOnly(['name', 'email', 'message']) &&
+             data.name is string &&
+             data.email is string &&
+             data.message is string &&
+             data.message.size() <= 2000;
+    }
+
+    match /users/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create, update: if request.auth != null && request.auth.uid == uid &&
+                            isValidUser(request.resource.data, uid);
+    }
+
+    match /contactMessages/{messageId} {
+      allow create: if request.auth != null &&
+                    isValidContactMessage(request.resource.data);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- tighten user document rules to require uid/name/email while allowing extra fields
- add contactMessages rule for authenticated creates with length-checked message
- sync auth flows with Firestore: user docs include uid/name/email/age, profile updates persist, and contact form requires auth

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b634fa14832da2dea5d04d334510