### PR TITLE
Validate and monitor contact messages

### DIFF
--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -6,6 +6,7 @@ import { useNavigation } from 'expo-router';
 import { useUser } from '../../context/userContext';
 import { auth, db } from '../../firebaseConfig';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { logContactMessage } from '../../services/monitoringService';
 
 const ContactUsScreen = () => {
 
@@ -22,6 +23,17 @@ const ContactUsScreen = () => {
             Alert.alert('Error', 'You must be logged in to send a message');
             return;
         }
+
+        if (!name.trim() || !email.trim() || !message.trim()) {
+            Alert.alert('Error', 'All fields are required');
+            return;
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            Alert.alert('Error', 'Please enter a valid email address');
+            return;
+        }
         setLoading(true);
         try {
             await addDoc(collection(db, 'contactMessages'), {
@@ -30,6 +42,7 @@ const ContactUsScreen = () => {
                 message,
                 createdAt: serverTimestamp(),
             });
+            logContactMessage({ name, email, message });
             Alert.alert('Success', 'Message sent successfully');
             navigation.pop();
         } catch (e) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,9 +10,13 @@ service cloud.firestore {
 
     function isValidContactMessage(data) {
       return data.keys().hasOnly(['name', 'email', 'message']) &&
-             data.name is string &&
+             data.name is string && data.name.size() > 0 &&
              data.email is string &&
+             data.email.size() > 0 &&
+             // Disallow whitespace in email addresses
+             data.email.matches("^[^@\s]+@[^@\s]+\.[^@\s]+$") &&
              data.message is string &&
+             data.message.size() > 0 &&
              data.message.size() <= 2000;
     }
 

--- a/services/monitoringService.js
+++ b/services/monitoringService.js
@@ -1,0 +1,30 @@
+import { Platform } from 'react-native';
+import app from '../firebaseConfig';
+
+let analytics;
+let logEventFn;
+if (Platform.OS === 'web') {
+  const measurementId = app.options?.measurementId;
+  if (measurementId) {
+    const analyticsModule = require('firebase/analytics');
+    analytics = analyticsModule.getAnalytics(app);
+    logEventFn = analyticsModule.logEvent;
+  }
+}
+
+export const logContactMessage = ({ name, email, message }) => {
+  if (!analytics) return;
+  try {
+    logEventFn(analytics, 'contact_message_submitted', {
+      name,
+      email,
+      message_length: message.length,
+    });
+  } catch (error) {
+    console.log('Failed to log contact message', error);
+  }
+};
+
+export default {
+  logContactMessage,
+};


### PR DESCRIPTION
## Summary
- enforce client-side validation for contact form fields and log submissions to a monitoring service
- add monitoring service for analytics logging of contact messages (web-only)
- tighten Firestore rules to validate contact message fields, escape whitespace in email regex, and ensure authenticated writes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dfa4c1f0832db91f19e32e98df04