### PR TITLE
Allow optional createdAt field in contact message rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,7 @@ service cloud.firestore {
     }
 
     function isValidContactMessage(data) {
-      return data.keys().hasOnly(['name', 'email', 'message']) &&
+      return data.keys().hasOnly(['name', 'email', 'message', 'createdAt']) &&
              data.name is string && data.name.size() > 0 &&
              data.email is string &&
              data.email.size() > 0 &&
@@ -17,7 +17,8 @@ service cloud.firestore {
              data.email.matches("^[^@\s]+@[^@\s]+\.[^@\s]+$") &&
              data.message is string &&
              data.message.size() > 0 &&
-             data.message.size() <= 2000;
+             data.message.size() <= 2000 &&
+             (!data.keys().hasAny(['createdAt']) || data.createdAt is timestamp);
     }
 
     match /users/{uid} {


### PR DESCRIPTION
## Summary
- permit optional `createdAt` timestamp in contact message validation

## Testing
- `npm test`
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f61cb1d0832d8d0924e097b4a82a