### PR TITLE
Limit contact form message length

### DIFF
--- a/app/contactUs/contactUsScreen.js
+++ b/app/contactUs/contactUsScreen.js
@@ -118,6 +118,7 @@ const ContactUsScreen = () => {
                     }}
                     placeholder="Write here..."
                     placeholderTextColor={Colors.grayColor}
+                    maxLength={2000}
                     multiline
                     numberOfLines={4}
                     textAlignVertical="top"


### PR DESCRIPTION
## Summary
- cap Contact Us message input at 2000 characters

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: ESLint is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f880b5b4832dbe67d3d5e46af231