### PR TITLE
Use Cloud Function for public user data and tighten rules

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -2,6 +2,7 @@ import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
+import { getFunctions } from "firebase/functions";
 
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
@@ -18,5 +19,6 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
+export const functions = getFunctions(app);
 
 export default app;

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,7 +22,7 @@ service cloud.firestore {
     }
 
     match /users/{uid} {
-      allow read: if request.auth != null && request.auth.uid == uid;
+      allow get: if request.auth != null && request.auth.uid == uid;
       allow create, update: if request.auth != null && request.auth.uid == uid &&
                             isValidUser(request.resource.data, uid);
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,36 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+exports.getPublicUsers = functions.https.onCall(async (data = {}, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Auth required');
+  }
+
+  const { limit = 20, startAfter } = data;
+
+  let query = admin.firestore().collection('users').orderBy('uid').limit(limit);
+  if (startAfter) {
+    query = query.startAfter(startAfter);
+  }
+
+  const snapshot = await query.get();
+  const users = snapshot.docs.map((doc) => {
+    const d = doc.data();
+    return {
+      id: doc.id,
+      name: d.name ?? '',
+      photoURL: d.photoURL ?? null,
+      age: d.age ?? null,
+      gender: d.gender ?? null,
+      bio: d.bio ?? '',
+    };
+  });
+
+  const lastDoc = snapshot.docs[snapshot.docs.length - 1];
+  const nextCursor = lastDoc ? lastDoc.get('uid') : null;
+
+  return { users, nextCursor };
+});
+

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,8 +1,13 @@
-import { db } from '../firebaseConfig';
-import { collection, getDocs } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebaseConfig';
 
-export async function fetchUsers() {
-  const snapshot = await getDocs(collection(db, 'users'));
-  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+export async function fetchUsers({ limit = 20, startAfter } = {}) {
+  const getPublicUsers = httpsCallable(functions, 'getPublicUsers');
+  try {
+    const result = await getPublicUsers({ limit, startAfter });
+    return { users: result.data.users, nextCursor: result.data.nextCursor };
+  } catch (e) {
+    throw new Error('Failed to fetch users. Please try again later.');
+  }
 }
 


### PR DESCRIPTION
## Summary
- Add Firebase Functions export to client config
- Move user fetching to new `getPublicUsers` Cloud Function
- Restrict Firestore user reads to authenticated owner only
- Enforce auth check in `getPublicUsers` with `HttpsError`
- Support pagination in `getPublicUsers` and `fetchUsers`
- Return only sanitized public profile fields in `getPublicUsers`
- Wrap `fetchUsers` callable in try/catch to return sanitized results or a friendly error

## Testing
- `CI=true npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f80f3c88832d868cd94980ce8fe4