### PR TITLE
Return nextCursor on user array in fetchUsers

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -5,7 +5,9 @@ export async function fetchUsers({ limit = 20, startAfter } = {}) {
   const getPublicUsers = httpsCallable(functions, 'getPublicUsers');
   try {
     const result = await getPublicUsers({ limit, startAfter });
-    return { users: result.data.users, nextCursor: result.data.nextCursor };
+    const { users, nextCursor } = result.data;
+    users.nextCursor = nextCursor;
+    return users;
   } catch (e) {
     throw new Error('Failed to fetch users. Please try again later.');
   }


### PR DESCRIPTION
## Summary
- expose nextCursor directly on returned user array from fetchUsers

## Testing
- ⚠️ `npm run lint` *(failed: TypeError: fetch failed)*
- ⚠️ `npm test -- --watchAll=false` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c62cf75100832dbe1e2c87a55c70f6