### PR TITLE
Include additional public user fields

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -25,6 +25,11 @@ exports.getPublicUsers = functions.https.onCall(async (data = {}, context) => {
       age: d.age ?? null,
       gender: d.gender ?? null,
       bio: d.bio ?? '',
+      image: d.image ?? '',
+      address: d.address ?? '',
+      distance: d.distance ?? null,
+      profession: d.profession ?? '',
+      isFavorite: d.isFavorite ?? false,
     };
   });
 


### PR DESCRIPTION
## Summary
- expose extra public user fields (image, address, distance, profession, isFavorite) with safe defaults in `getPublicUsers`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68c62e1d3a88832daf476257c44b9c9f