### PR TITLE
Return users and cursor from fetchUsers

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -6,8 +6,7 @@ export async function fetchUsers({ limit = 20, startAfter } = {}) {
   try {
     const result = await getPublicUsers({ limit, startAfter });
     const { users, nextCursor } = result.data;
-    users.nextCursor = nextCursor;
-    return users;
+    return { users, nextCursor };
   } catch (e) {
     throw new Error('Failed to fetch users. Please try again later.');
   }


### PR DESCRIPTION
## Summary
- return `{ users, nextCursor }` from `fetchUsers` instead of mutating the users array
- use cursor/done/loading state on the home screen with a `loadMore` helper to paginate and stop when all users loaded
- drop `cardLength` logic and trigger `loadMore` if all cards are removed
- remove card when it leaves the screen and mark pagination done when no users are fetched

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint is not installed. Skipping lint.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7149988e8832daf2c6f769b514d78