### PR TITLE
feat: configure region and runtime limits

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -19,6 +19,6 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
-export const functions = getFunctions(app);
+export const functions = getFunctions(app, "us-central1");
 
 export default app;

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,7 +3,10 @@ const admin = require('firebase-admin');
 
 admin.initializeApp();
 
-exports.getPublicUsers = functions.https.onCall(async (data = {}, context) => {
+exports.getPublicUsers = functions
+  .region('us-central1')
+  .runWith({ memory: '256MB', timeoutSeconds: 60 })
+  .https.onCall(async (data = {}, context) => {
   if (!context.auth) {
     throw new functions.https.HttpsError('unauthenticated', 'Auth required');
   }


### PR DESCRIPTION
## Summary
- configure getPublicUsers cloud function with region us-central1 and runtime limits
- align Firebase client to call Functions in the us-central1 region

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*
- `npx firebase deploy --only functions:getPublicUsers` *(fails: command not found: npx)*

------
https://chatgpt.com/codex/tasks/task_e_68c7659f2978832da5881ee0987d470f