### PR TITLE
Configure Jest and CI for stable tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -1,1 +1,5 @@
-test('CI plumbing', () => expect(true).toBe(true));
+describe('smoke', () => {
+  it('runs', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,49 @@
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(),
+  getApp: jest.fn(),
+  getApps: jest.fn(() => []),
+}));
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+  onAuthStateChanged: jest.fn((auth, cb) => {
+    cb(null);
+    return jest.fn();
+  }),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(async () => ({
+    exists: () => false,
+    data: () => null,
+  })),
+  setDoc: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('firebase/functions', () => ({
+  getFunctions: jest.fn(),
+  httpsCallable: jest.fn(() => async () => ({
+    data: { users: [], nextCursor: null },
+  })),
+}));
+
+jest.mock('expo', () => ({}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }) => children,
+}));
+
+jest.mock('expo-router', () => ({}));
+
+jest.mock('react-tinder-card', () => ({
+  __esModule: true,
+  default: ({ children }) => children,
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return Reanimated;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,10 +48,10 @@
         "@babel/core": "^7.25.2",
         "@types/jest": "^29.5.12",
         "@types/react": "~19.0.10",
-        "@types/react-test-renderer": "^18.3.0",
+        "@types/react-test-renderer": "^19.0.0",
         "jest": "^29.2.1",
         "jest-expo": "~53.0.9",
-        "react-test-renderer": "18.3.1",
+        "react-test-renderer": "19.0.0",
         "typescript": "^5.3.3"
       }
     },
@@ -4037,24 +4037,12 @@
       }
     },
     "node_modules/@types/react-test-renderer": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
-      "integrity": "sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/react": "^18"
-      }
-    },
-    "node_modules/@types/react-test-renderer/node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "@types/react": "^19"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10380,35 +10368,17 @@
       "license": "MIT"
     },
     "node_modules/react-test-renderer": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
-      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^18.3.1",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.2"
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-tinder-card": {

--- a/package.json
+++ b/package.json
@@ -67,10 +67,10 @@
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.0.10",
-    "@types/react-test-renderer": "^18.3.0",
+    "@types/react-test-renderer": "^19.0.0",
     "jest": "^29.2.1",
     "jest-expo": "~53.0.9",
-    "react-test-renderer": "18.3.1",
+    "react-test-renderer": "19.0.0",
     "typescript": "^5.3.3",
     "identity-obj-proxy": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,18 @@
     "lint": "node scripts/run-eslint.js"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native|@react-navigation|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|@expo/vector-icons|expo-font|expo-asset|expo-constants|expo-router|@expo/.*|firebase/.*))"
+    ],
+    "moduleNameMapper": {
+      "\\.(png|jpg|jpeg|gif|svg)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less|scss|sass)$": "identity-obj-proxy"
+    }
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
@@ -60,7 +71,8 @@
     "jest": "^29.2.1",
     "jest-expo": "~53.0.9",
     "react-test-renderer": "18.3.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "identity-obj-proxy": "^3.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- stub Firebase auth, firestore, and functions APIs with predictable test data
- mock Expo LinearGradient, React Native Reanimated, and renderable react-tinder-card
- map image assets to a file stub and include a smoke test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c76f325518832db1be53e5ab83f982