### PR TITLE
chore: drop test renderer and align react v19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "expo-system-ui": "~5.0.10",
         "expo-web-browser": "~14.2.0",
         "firebase": "^12.2.1",
-        "react": "19.0.0",
-        "react-dom": "19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-native": "0.79.5",
         "react-native-collapsible-toolbar": "^0.1.2",
         "react-native-element-dropdown": "^2.12.4",
@@ -47,11 +47,9 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/jest": "^29.5.12",
-        "@types/react": "~19.0.10",
-        "@types/react-test-renderer": "^19.0.0",
+        "@types/react": "^19.0.0",
         "jest": "^29.2.1",
         "jest-expo": "~53.0.9",
-        "react-test-renderer": "19.0.0",
         "typescript": "^5.3.3"
       }
     },
@@ -4034,15 +4032,6 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-test-renderer": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "^19"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
     "firebase": "^12.2.1",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-native": "0.79.5",
     "react-native-collapsible-toolbar": "^0.1.2",
     "react-native-element-dropdown": "^2.12.4",
@@ -66,11 +66,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",
-    "@types/react": "~19.0.10",
-    "@types/react-test-renderer": "^19.0.0",
+    "@types/react": "^19.0.0",
     "jest": "^29.2.1",
     "jest-expo": "~53.0.9",
-    "react-test-renderer": "19.0.0",
     "typescript": "^5.3.3",
     "identity-obj-proxy": "^3.0.0"
   },


### PR DESCRIPTION
## Summary
- remove react-test-renderer and its type definitions
- upgrade React and ReactDOM to caret 19 and bump @types/react
- refresh package-lock for updated dependencies

## Testing
- `npm ci --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/identity-obj-proxy)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7803663e8832db3f1f1a1a03f58fe