### PR TITLE
fix: use react-native Firebase auth imports

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,9 +1,9 @@
 import { initializeApp, getApp, getApps } from "firebase/app";
+import { getAuth } from "firebase/auth";
 import {
-  getAuth,
   initializeAuth,
   getReactNativePersistence,
-} from "firebase/auth";
+} from "firebase/auth/react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Platform } from "react-native";
 import { getFirestore } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- import React Native specific auth helpers from `firebase/auth/react-native`
## Testing
- `npm test`
- `npm run lint` (ESLint is not installed)


------
https://chatgpt.com/codex/tasks/task_e_68c7f2f4c588832daf3220046122603c