### PR TITLE
Wait for auth init before anonymous sign-in

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -4,6 +4,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import { AppState, LogBox, StatusBar } from 'react-native';
 import { UserProvider } from '../context/userContext';
+import { ensureAuth } from '../services/authService';
 
 LogBox.ignoreAllLogs();
 
@@ -22,6 +23,7 @@ export default function RootLayout() {
     if (loaded) {
       SplashScreen.hideAsync();
     }
+    ensureAuth();
     const subscription = AppState.addEventListener("change", (_) => {
       StatusBar.setBarStyle("light-content");
     });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,13 +4,18 @@ jest.mock('firebase/app', () => ({
   getApps: jest.fn(() => []),
 }));
 
+const authMock = { currentUser: null };
+
 jest.mock('firebase/auth', () => ({
-  getAuth: jest.fn(),
-  initializeAuth: jest.fn(),
+  getAuth: jest.fn(() => authMock),
+  initializeAuth: jest.fn(() => authMock),
   getReactNativePersistence: jest.fn(),
-  signInAnonymously: jest.fn(() => Promise.resolve()),
+  signInAnonymously: jest.fn(async () => {
+    authMock.currentUser = { uid: 'anon' };
+    return { user: authMock.currentUser };
+  }),
   onAuthStateChanged: jest.fn((auth, cb) => {
-    cb(null);
+    cb(auth.currentUser);
     return jest.fn();
   }),
 }));

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,0 +1,28 @@
+import { onAuthStateChanged, signInAnonymously } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
+
+let authInitPromise;
+
+export async function waitForAuthInit(timeout = 500) {
+  if (auth.currentUser) return;
+  if (!authInitPromise) {
+    authInitPromise = new Promise((resolve) => {
+      const unsub = onAuthStateChanged(auth, () => {
+        unsub();
+        resolve();
+      });
+      setTimeout(() => {
+        unsub();
+        resolve();
+      }, timeout);
+    });
+  }
+  await authInitPromise;
+}
+
+export async function ensureAuth() {
+  await waitForAuthInit();
+  if (!auth.currentUser) {
+    await signInAnonymously(auth);
+  }
+}

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,11 +1,9 @@
 import { httpsCallable } from 'firebase/functions';
-import { signInAnonymously } from 'firebase/auth';
-import { functions, auth } from '../firebaseConfig';
+import { functions } from '../firebaseConfig';
+import { ensureAuth } from './authService';
 
 export async function fetchUsers({ limit = 20, startAfter } = {}) {
-  if (!auth.currentUser) {
-    await signInAnonymously(auth);
-  }
+  await ensureAuth();
   const getPublicUsers = httpsCallable(functions, 'getPublicUsers');
   try {
     const result = await getPublicUsers({ limit, startAfter });


### PR DESCRIPTION
## Summary
- Wait for initial auth state before API calls and sign-ins by introducing `waitForAuthInit` and `ensureAuth` utilities【F:services/authService.js†L1-L28】
- Use `ensureAuth` in app startup and fetchUsers to avoid overwriting existing sessions【F:app/_layout.js†L7-L26】【F:services/userService.js†L1-L7】
- Update Jest mocks to simulate auth state and anonymous sign-in【F:jest.setup.js†L7-L21】

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c82fbf9690832db3b6b81fc0efa6b7