### PR TITLE
Ensure auth init waits for auth state event

### DIFF
--- a/services/authService.js
+++ b/services/authService.js
@@ -3,18 +3,13 @@ import { auth } from '../firebaseConfig';
 
 let authInitPromise;
 
-export async function waitForAuthInit(timeout = 500) {
-  if (auth.currentUser) return;
+export async function waitForAuthInit() {
   if (!authInitPromise) {
     authInitPromise = new Promise((resolve) => {
-      const unsub = onAuthStateChanged(auth, () => {
-        unsub();
+      const unsubscribe = onAuthStateChanged(auth, () => {
+        unsubscribe();
         resolve();
       });
-      setTimeout(() => {
-        unsub();
-        resolve();
-      }, timeout);
     });
   }
   await authInitPromise;


### PR DESCRIPTION
## Summary
- resolve `waitForAuthInit` only after the initial `onAuthStateChanged` callback instead of timing out
- call `signInAnonymously` in `ensureAuth` only when no user exists after initialization
- update the Firebase auth Jest mock to simulate async auth state notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8632e4264832da3cc8a1195bc6bb4