### PR TITLE
fix: use published @expo/vector-icons 14.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rn-rc-datingapp",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/vector-icons": "^14.2.0",
+        "@expo/vector-icons": "^14.1.0",
         "@miblanchard/react-native-slider": "^2.6.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/bottom-tabs": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.2.0",
+    "@expo/vector-icons": "^14.1.0",
     "@miblanchard/react-native-slider": "^2.6.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/bottom-tabs": "^7.4.2",


### PR DESCRIPTION
## Summary
- update @expo/vector-icons dependency to the published ^14.1.0 range
- align the package-lock.json entry with the new constraint

## Testing
- npm ci *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d20a2c4832d8f467084cb1954e1