### PR TITLE
Align Expo SDK 54 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ npm run reset-project
 
 This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
 
+## Fix deps
+
+If the dependency tree drifts from the Expo SDK 54 expectations, run the following commands to reinstall everything and verify the project:
+
+```bash
+rm -rf node_modules package-lock.json
+npm install
+npx expo-doctor
+npm run lint
+npm run build
+```
+
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@react-navigation/bottom-tabs": "^7.4.2",
         "@react-navigation/native": "^7.1.14",
         "@react-spring/native": "^9.5.5",
-        "expo": "54.0.2",
+        "expo": "~54.0.2",
         "expo-blur": "14.4.0",
         "expo-constants": "18.0.2",
         "expo-font": "13.4.0",
@@ -28,9 +28,9 @@
         "expo-system-ui": "5.1.0",
         "expo-web-browser": "14.4.0",
         "firebase": "^12.2.1",
-        "react": "19.0.0",
-        "react-dom": "19.0.0",
-        "react-native": "0.79.6",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "react-native": "0.76.1",
         "react-native-collapsible-toolbar": "^0.1.2",
         "react-native-element-dropdown": "^2.12.4",
         "react-native-gesture-handler": "2.24.2",
@@ -40,7 +40,7 @@
         "react-native-safe-area-context": "5.4.1",
         "react-native-screens": "4.11.2",
         "react-native-swipe-list-view": "^3.2.9",
-        "react-native-web": "0.20.2",
+        "react-native-web": "~0.19.12",
         "react-native-webview": "13.13.5",
         "react-tinder-card": "^1.6.4",
         "rn-range-slider": "^2.2.2"
@@ -48,9 +48,9 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/jest": "^29.5.12",
-        "@types/react": "^19.0.0",
+        "@types/react": "^18.3.3",
         "jest": "^29.7.0",
-        "jest-expo": "54.0.2",
+        "jest-expo": "~54.0.2",
         "typescript": "^5.3.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@react-navigation/bottom-tabs": "^7.4.2",
     "@react-navigation/native": "^7.1.14",
     "@react-spring/native": "^9.5.5",
-    "expo": "54.0.2",
+    "expo": "~54.0.2",
     "expo-blur": "14.4.0",
     "expo-constants": "18.0.2",
     "expo-font": "13.4.0",
@@ -46,9 +46,9 @@
     "expo-system-ui": "5.1.0",
     "expo-web-browser": "14.4.0",
     "firebase": "^12.2.1",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "react-native": "0.79.6",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-native": "0.76.1",
     "react-native-collapsible-toolbar": "^0.1.2",
     "react-native-element-dropdown": "^2.12.4",
     "react-native-gesture-handler": "2.24.2",
@@ -58,7 +58,7 @@
     "react-native-safe-area-context": "5.4.1",
     "react-native-screens": "4.11.2",
     "react-native-swipe-list-view": "^3.2.9",
-    "react-native-web": "0.20.2",
+    "react-native-web": "~0.19.12",
     "react-native-webview": "13.13.5",
     "react-tinder-card": "^1.6.4",
     "rn-range-slider": "^2.2.2"
@@ -66,9 +66,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",
-    "@types/react": "^19.0.0",
+    "@types/react": "^18.3.3",
     "jest": "^29.7.0",
-    "jest-expo": "54.0.2",
+    "jest-expo": "~54.0.2",
     "typescript": "^5.3.3"
   },
   "private": true


### PR DESCRIPTION
## Summary
- align expo, react, and react-native packages with the expected Expo SDK 54 versions
- update matching entries in the lockfile to keep dependency metadata in sync
- document the exact commands to reinstall dependencies and validate the project

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95be02dc0832dbd4e90983d4287f7