### PR TITLE
Stop removing package lock in CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: rm -rf node_modules package-lock.json
+      - run: rm -rf node_modules
       - run: npm ci --legacy-peer-deps
       - run: npm test


### PR DESCRIPTION
## Summary
- keep the npm lockfile intact during CI installs by only removing node_modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca3cd3e470832d99ae09cadeca9f25