### PR TITLE
Handle unauthenticated sessions without anonymous fallback

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -1,6 +1,6 @@
 import { useFonts } from 'expo-font';
 import { StatusBar, setStatusBarStyle } from 'expo-status-bar';
-import { Stack } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import { AppState, LogBox } from 'react-native';
@@ -22,20 +22,30 @@ export default function RootLayout() {
     Roboto_Medium: require("../assets/fonts/Roboto-Medium.ttf"),
     Roboto_Bold: require("../assets/fonts/Roboto-Bold.ttf"),
   });
+  const router = useRouter();
 
   useEffect(() => {
+    let isMounted = true;
+
     if (loaded) {
       SplashScreen.hideAsync();
       setStatusBarStyle('light');
     }
-    ensureAuth();
+
+    ensureAuth().then((result) => {
+      if (!result.ok && result.error?.code === 'no-auth' && isMounted) {
+        router.replace('/auth/loginScreen');
+      }
+    });
+
     const subscription = AppState.addEventListener('change', () => {
       setStatusBarStyle('light');
     });
     return () => {
+      isMounted = false;
       subscription.remove();
     };
-  }, [loaded]);
+  }, [loaded, router]);
 
   if (!loaded) {
     return null;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -16,11 +16,6 @@ jest.mock('firebase/auth', () => ({
   getAuth: jest.fn(() => mockAuth),
   initializeAuth: jest.fn(() => mockAuth),
   getReactNativePersistence: jest.fn(),
-  signInAnonymously: jest.fn(async () => {
-    const user = { uid: 'anon' };
-    mockAuth.triggerAuthStateChange(user);
-    return { user };
-  }),
   onAuthStateChanged: jest.fn((auth, cb) => {
     mockAuthListeners.add(cb);
     setTimeout(() => {
@@ -57,7 +52,25 @@ jest.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }) => children,
 }));
 
-jest.mock('expo-router', () => ({}));
+const mockRouter = {
+  replace: jest.fn(),
+  push: jest.fn(),
+  navigate: jest.fn(),
+  back: jest.fn(),
+};
+
+jest.mock('expo-router', () => ({
+  Stack: ({ children }) => children,
+  useRouter: () => mockRouter,
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    reset: jest.fn(),
+    goBack: jest.fn(),
+  }),
+  router: mockRouter,
+}));
 
 jest.mock('react-tinder-card', () => ({
   __esModule: true,

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,5 +1,6 @@
-import { onAuthStateChanged, signInAnonymously } from 'firebase/auth';
+import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from '../firebaseConfig';
+import { success, failure } from './result';
 
 let authInitPromise;
 
@@ -13,11 +14,14 @@ export async function waitForAuthInit() {
     });
   }
   await authInitPromise;
+  return success();
 }
 
 export async function ensureAuth() {
   await waitForAuthInit();
-  if (!auth.currentUser) {
-    await signInAnonymously(auth);
+  const user = auth.currentUser;
+  if (!user) {
+    return failure('no-auth');
   }
+  return success({ user });
 }

--- a/services/result.js
+++ b/services/result.js
@@ -1,0 +1,11 @@
+export function success(data) {
+  return typeof data === 'undefined' ? { ok: true } : { ok: true, data };
+}
+
+export function failure(code, message) {
+  const error = { code };
+  if (message) {
+    error.message = message;
+  }
+  return { ok: false, error };
+}

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,16 +1,21 @@
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebaseConfig';
 import { ensureAuth } from './authService';
+import { success, failure } from './result';
 
 export async function fetchUsers({ limit = 20, startAfter } = {}) {
-  await ensureAuth();
+  const authResult = await ensureAuth();
+  if (!authResult.ok) {
+    return authResult;
+  }
+
   const getPublicUsers = httpsCallable(functions, 'getPublicUsers');
   try {
     const result = await getPublicUsers({ limit, startAfter });
     const { users, nextCursor } = result.data;
-    return { users, nextCursor };
+    return success({ users, nextCursor });
   } catch (e) {
-    throw new Error('Failed to fetch users. Please try again later.');
+    console.error('Failed to fetch users. Please try again later.', e);
+    return failure('fetch-users-failed', 'Failed to fetch users. Please try again later.');
   }
 }
-


### PR DESCRIPTION
## Summary
- add a shared Result helper and return it from the auth service instead of silently creating anonymous sessions
- update the user service and home screen to respect the Result contract and redirect to the login flow when authentication is missing
- wire the root layout and Jest setup to the new Result pattern and router usage

## Testing
- `npm test` *(fails: jest command not found because dependencies are not installed in the environment)*
- `npm install` *(fails: registry access returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca36ec2264832d887538d081206992