### PR TITLE
Remove Firebase App Check and update Babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = function (api) {
     plugins: [
       'expo-router/babel',
       'react-native-worklets/plugin',
+      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,5 +1,4 @@
 import { initializeApp, getApp, getApps } from "firebase/app";
-import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check";
 import {
   getAuth,
   initializeAuth,
@@ -22,20 +21,6 @@ const firebaseConfig = {
 };
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
-
-if (
-  process.env.NODE_ENV === "development" ||
-  (typeof __DEV__ !== "undefined" && __DEV__)
-) {
-  globalThis.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
-}
-
-initializeAppCheck(app, {
-  provider: new ReCaptchaV3Provider(
-    process.env.EXPO_PUBLIC_RECAPTCHA_SITE_KEY
-  ),
-  isTokenAutoRefreshEnabled: true,
-});
 
 const auth =
   Platform.OS === "web"


### PR DESCRIPTION
## Summary
- remove App Check setup from the Firebase configuration
- add react-native-reanimated Babel plugin alongside existing plugins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb151efe98832d93d9528cbea8cef1