### PR TITLE
Update Babel plugins configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,10 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      'expo-router/babel',
-      'react-native-worklets/plugin',
-      'react-native-reanimated/plugin',
-    ],
+    plugins: ['expo-router/babel', 'react-native-worklets/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- remove the deprecated `react-native-reanimated/plugin` entry from the Babel plugin list
- ensure only `expo-router/babel` and `react-native-worklets/plugin` are configured, with worklets last

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb1ff65d9c832db705882007c4c1f8