### PR TITLE
Move auth routing into splash screen

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -1,11 +1,10 @@
 import { useFonts } from 'expo-font';
 import { StatusBar, setStatusBarStyle } from 'expo-status-bar';
-import { Stack, useRouter } from 'expo-router';
+import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { AppState, LogBox } from 'react-native';
 import { UserProvider } from '../context/userContext';
-import { ensureAuth } from '../services/authService';
 
 LogBox.ignoreAllLogs();
 
@@ -16,38 +15,62 @@ SplashScreen.preventAutoHideAsync().catch(() => {
 
 export default function RootLayout() {
 
-  const [loaded] = useFonts({
+  const [loaded, error] = useFonts({
     Roboto_Light: require("../assets/fonts/Roboto-Light.ttf"),
     Roboto_Regular: require("../assets/fonts/Roboto-Regular.ttf"),
     Roboto_Medium: require("../assets/fonts/Roboto-Medium.ttf"),
     Roboto_Bold: require("../assets/fonts/Roboto-Bold.ttf"),
   });
-  const router = useRouter();
+  const [fontLoadTimedOut, setFontLoadTimedOut] = useState(false);
 
   useEffect(() => {
-    let isMounted = true;
-
     if (loaded) {
       SplashScreen.hideAsync();
       setStatusBarStyle('light');
     }
 
-    ensureAuth().then((result) => {
-      if (!result.ok && result.error?.code === 'no-auth' && isMounted) {
-        router.replace('/auth/loginScreen');
-      }
-    });
+    if (error) {
+      console.error('Failed to load custom fonts. Falling back to system defaults.', error);
+      SplashScreen.hideAsync();
+      setStatusBarStyle('light');
+    }
 
     const subscription = AppState.addEventListener('change', () => {
       setStatusBarStyle('light');
     });
     return () => {
-      isMounted = false;
       subscription.remove();
     };
-  }, [loaded, router]);
+  }, [loaded, error]);
 
-  if (!loaded) {
+  useEffect(() => {
+    if (loaded || error) {
+      return;
+    }
+
+    let isActive = true;
+
+    const timeoutId = setTimeout(() => {
+      if (isActive) {
+        console.warn('Font loading timed out. Hiding splash screen and rendering fallback UI.');
+        setFontLoadTimedOut(true);
+      }
+    }, 5000);
+
+    return () => {
+      isActive = false;
+      clearTimeout(timeoutId);
+    };
+  }, [loaded, error]);
+
+  useEffect(() => {
+    if (fontLoadTimedOut && !loaded) {
+      SplashScreen.hideAsync();
+      setStatusBarStyle('light');
+    }
+  }, [fontLoadTimedOut, loaded]);
+
+  if (!loaded && !error && !fontLoadTimedOut) {
     return null;
   }
 

--- a/app/index.js
+++ b/app/index.js
@@ -2,20 +2,21 @@ import { StyleSheet, View, Image } from 'react-native'
 import React, { useEffect } from 'react'
 import { Colors, Sizes } from '../constants/styles'
 import MyStatusBar from '../components/myStatusBar'
-import { useNavigation } from 'expo-router'
+import { useRouter } from 'expo-router'
+import { ensureAuth } from '../services/authService'
 
 const SplashScreen = () => {
 
-    const navigation = useNavigation();
+    const router = useRouter();
 
     useEffect(() => {
-        const timer = setTimeout(() => {
-            navigation.push('auth/loginScreen')
-        }, 2000);
-        return () => {
-            clearTimeout(timer);
-        }
-    }, [])
+        const redirect = async () => {
+            const result = await ensureAuth();
+            router.replace(result.ok ? '/(tabs)' : '/auth/loginScreen');
+        };
+
+        redirect();
+    }, [router])
 
     return (
         <View style={{ flex: 1, backgroundColor: Colors.whiteColor }}>


### PR DESCRIPTION
## Summary
- remove authentication routing from the root layout so it only handles splash and font state
- run ensureAuth from the splash screen index route and replace to the authenticated or login stack accordingly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb7c066b48832db776f3e062e41fac