### PR TITLE
Protect profile fetch from auth race conditions

### DIFF
--- a/context/userContext.js
+++ b/context/userContext.js
@@ -10,24 +10,60 @@ export const UserProvider = ({ children }) => {
   const [profile, setProfile] = useState(undefined);
 
   useEffect(() => {
+    let isMounted = true;
+    let pendingUid = null;
+
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!isMounted) {
+        return;
+      }
+
       if (user) {
+        const requestedUid = user.uid;
+        pendingUid = requestedUid;
+        setProfile(undefined);
+
         try {
-          const userDoc = await getDoc(doc(db, 'users', user.uid));
+          const userDoc = await getDoc(doc(db, 'users', requestedUid));
+
+          if (!isMounted) {
+            return;
+          }
+
+          const currentUid = auth.currentUser?.uid;
+          if (!currentUid || currentUid !== requestedUid || pendingUid !== requestedUid) {
+            return;
+          }
+
           if (userDoc.exists()) {
             setProfile(userDoc.data());
           } else {
             setProfile(null);
           }
         } catch (error) {
+          if (!isMounted) {
+            return;
+          }
+
+          const currentUid = auth.currentUser?.uid;
+          if (!currentUid || currentUid !== requestedUid || pendingUid !== requestedUid) {
+            return;
+          }
+
           console.error('Error fetching user profile:', error);
           setProfile(null);
         }
       } else {
+        pendingUid = null;
         setProfile(null);
       }
     });
-    return unsubscribe;
+
+    return () => {
+      isMounted = false;
+      pendingUid = null;
+      unsubscribe();
+    };
   }, []);
 
   const value = useMemo(() => ({ profile, setProfile }), [profile]);


### PR DESCRIPTION
## Summary
- capture the signed-in user's uid before fetching the profile document
- only apply profile updates when the auth state still matches the in-flight request
- clear profile state immediately on auth changes and guard against updates after unmount

## Testing
- npm test *(fails: jest binary unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8ffaac48832db8f0b0cc4712cec9