### PR TITLE
Handle missing pagination cursors gracefully

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -21,7 +21,7 @@ exports.getPublicUsers = functions
   }
   const clampedLimit = Math.min(limit, 100);
 
-  let cursorSnap = null;
+  let startAfterId = null;
   if (startAfter !== undefined && startAfter !== null) {
     if (typeof startAfter !== 'string') {
       throw new functions.https.HttpsError(
@@ -30,17 +30,9 @@ exports.getPublicUsers = functions
       );
     }
 
-    cursorSnap = await admin
-      .firestore()
-      .collection('users')
-      .doc(startAfter)
-      .get();
-
-    if (!cursorSnap.exists) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'Invalid cursor'
-      );
+    const trimmed = startAfter.trim();
+    if (trimmed.length > 0) {
+      startAfterId = trimmed;
     }
   }
 
@@ -63,8 +55,8 @@ exports.getPublicUsers = functions
       )
       .limit(clampedLimit);
 
-    if (cursorSnap) {
-      query = query.startAfter(cursorSnap);
+    if (startAfterId) {
+      query = query.startAfter(startAfterId);
     }
 
     const snapshot = await query.get();


### PR DESCRIPTION
## Summary
- relax getPublicUsers cursor validation to accept any non-empty string ID
- pass the provided cursor directly to startAfter when ordering by document ID so missing docs no longer throw

## Testing
- npm test -- --watchAll=false *(fails: jest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d042d53188832d89b1421b7796c852