### PR TITLE
Add Firestore rules for swipes and matches messaging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,51 @@ service cloud.firestore {
              (!data.keys().hasAny(['createdAt']) || data.createdAt is timestamp);
     }
 
+    function isValidSwipe(data) {
+      return data.keys().hasOnly(['from', 'to', 'liked', 'createdAt']) &&
+             data.keys().hasAll(['from', 'to', 'liked', 'createdAt']) &&
+             data.from is string && data.from.size() > 0 &&
+             data.to is string && data.to.size() > 0 &&
+             data.from != data.to &&
+             data.liked is bool &&
+             data.createdAt is timestamp;
+    }
+
+    function isValidMatch(data) {
+      return data.keys().hasOnly(['users', 'matchedAt']) &&
+             data.keys().hasAll(['users', 'matchedAt']) &&
+             data.users is list && data.users.size() == 2 &&
+             data.users[0] is string && data.users[0].size() > 0 &&
+             data.users[1] is string && data.users[1].size() > 0 &&
+             data.users[0] != data.users[1] &&
+             data.matchedAt is timestamp;
+    }
+
+    function matchExists(matchId) {
+      return exists(/databases/$(database)/documents/matches/$(matchId));
+    }
+
+    function matchUsers(matchId) {
+      return get(/databases/$(database)/documents/matches/$(matchId)).data.users;
+    }
+
+    function isUserInMatch(matchId, uid) {
+      return matchExists(matchId) &&
+             matchUsers(matchId) is list &&
+             uid in matchUsers(matchId);
+    }
+
+    function isValidMatchMessage(data, matchId) {
+      return matchExists(matchId) &&
+             matchUsers(matchId) is list &&
+             data.keys().hasOnly(['senderId', 'content', 'createdAt']) &&
+             data.keys().hasAll(['senderId', 'content', 'createdAt']) &&
+             data.senderId is string && data.senderId.size() > 0 &&
+             data.content is string && data.content.size() > 0 &&
+             data.createdAt is timestamp &&
+             data.senderId in matchUsers(matchId);
+    }
+
     match /users/{uid} {
       allow get: if request.auth != null && request.auth.uid == uid;
       allow create, update: if request.auth != null && request.auth.uid == uid &&
@@ -44,6 +89,40 @@ service cloud.firestore {
     match /contactMessages/{messageId} {
       allow create: if request.auth != null &&
                     isValidContactMessage(request.resource.data);
+    }
+
+    match /swipes/{swipeId} {
+      allow create: if request.auth != null &&
+                    request.auth.uid == request.resource.data.from &&
+                    isValidSwipe(request.resource.data);
+    }
+
+    match /matches/{matchId} {
+      allow create: if request.auth != null &&
+                    request.auth.uid in request.resource.data.users &&
+                    isValidMatch(request.resource.data);
+
+      allow read: if request.auth != null &&
+                  request.auth.uid in resource.data.users;
+
+      allow update: if request.auth != null &&
+                    isUserInMatch(matchId, request.auth.uid) &&
+                    isValidMatch(request.resource.data) &&
+                    request.resource.data.users == resource.data.users &&
+                    request.resource.data.matchedAt == resource.data.matchedAt;
+
+      allow delete: if request.auth != null &&
+                    isUserInMatch(matchId, request.auth.uid);
+
+      match /messages/{messageId} {
+        allow create: if request.auth != null &&
+                       isUserInMatch(matchId, request.auth.uid) &&
+                       request.auth.uid == request.resource.data.senderId &&
+                       isValidMatchMessage(request.resource.data, matchId);
+
+        allow read: if request.auth != null &&
+                    isUserInMatch(matchId, request.auth.uid);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add validation helpers for swipe, match, and match message documents
- secure swipes creation and limit matches access to participating users
- restrict match message reads to participants and limit messages to create-only writes while enforcing field types
- ensure match document updates keep the existing participants and timestamp unchanged
- require swipes to be between different users and match documents to list distinct participants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d15826857c832d9600910f747f4f6c