### PR TITLE
Restrict match documents to read only

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -98,21 +98,8 @@ service cloud.firestore {
     }
 
     match /matches/{matchId} {
-      allow create: if request.auth != null &&
-                    request.auth.uid in request.resource.data.users &&
-                    isValidMatch(request.resource.data);
-
       allow read: if request.auth != null &&
                   request.auth.uid in resource.data.users;
-
-      allow update: if request.auth != null &&
-                    isUserInMatch(matchId, request.auth.uid) &&
-                    isValidMatch(request.resource.data) &&
-                    request.resource.data.users == resource.data.users &&
-                    request.resource.data.matchedAt == resource.data.matchedAt;
-
-      allow delete: if request.auth != null &&
-                    isUserInMatch(matchId, request.auth.uid);
 
       match /messages/{messageId} {
         allow create: if request.auth != null &&


### PR DESCRIPTION
## Summary
- restrict match documents to read-only access for participants by removing write permissions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1c0867b94832da78008a132d89c0c