### PR TITLE
Adjust swipe resurfacing cooldown

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -3,7 +3,11 @@ import { functions } from '../firebaseConfig';
 import { ensureAuth } from './authService';
 import { success, failure } from './result';
 
-export async function fetchSwipeCandidates({ limit = 20, startAfter } = {}) {
+export async function fetchSwipeCandidates({
+  limit = 20,
+  startAfter,
+  cooldownDays = 14,
+} = {}) {
   const authResult = await ensureAuth();
   if (!authResult.ok) {
     return authResult;
@@ -11,7 +15,7 @@ export async function fetchSwipeCandidates({ limit = 20, startAfter } = {}) {
 
   const getSwipeCandidates = httpsCallable(functions, 'getSwipeCandidates');
   try {
-    const result = await getSwipeCandidates({ limit, startAfter });
+    const result = await getSwipeCandidates({ limit, startAfter, cooldownDays });
     const { users, nextCursor } = result.data;
     return success({ users, nextCursor });
   } catch (e) {


### PR DESCRIPTION
## Summary
- allow the swipe candidate function to resurface past passes only after a configurable cooldown period
- forward the cooldownDays option from the client service when requesting candidates
- store daily seen candidate ids on the home screen to avoid re-showing profiles multiple times in one day

## Testing
- npm run lint
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68d3897a5cc4832db20d750a4e62f133