### PR TITLE
Adjust swipe candidate cooldown defaults

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -133,7 +133,7 @@ exports.getSwipeCandidates = functions
       throw new functions.https.HttpsError('unauthenticated', 'Auth required');
     }
 
-    const { limit = 20, startAfter, cooldownDays = 14 } = data;
+    const { limit = 20, startAfter, cooldownDays } = data;
 
     if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
       throw new functions.https.HttpsError(
@@ -143,9 +143,8 @@ exports.getSwipeCandidates = functions
     }
 
     if (
-      typeof cooldownDays !== 'number' ||
-      Number.isNaN(cooldownDays) ||
-      cooldownDays < 0
+      cooldownDays !== undefined &&
+      (typeof cooldownDays !== 'number' || Number.isNaN(cooldownDays) || cooldownDays < 0)
     ) {
       throw new functions.https.HttpsError(
         'invalid-argument',
@@ -155,7 +154,8 @@ exports.getSwipeCandidates = functions
 
     const clampedLimit = Math.min(limit, 100);
     const fetchLimit = Math.min(clampedLimit + 1, 101);
-    const cooldownMillis = cooldownDays * 24 * 60 * 60 * 1000;
+    const cd = Math.max(5, cooldownDays ?? 7);
+    const cooldownMillis = cd * 24 * 60 * 60 * 1000;
 
     let startAfterId = null;
     if (startAfter !== undefined && startAfter !== null) {

--- a/services/userService.js
+++ b/services/userService.js
@@ -6,7 +6,7 @@ import { success, failure } from './result';
 export async function fetchSwipeCandidates({
   limit = 20,
   startAfter,
-  cooldownDays = 14,
+  cooldownDays,
 } = {}) {
   const authResult = await ensureAuth();
   if (!authResult.ok) {
@@ -15,7 +15,11 @@ export async function fetchSwipeCandidates({
 
   const getSwipeCandidates = httpsCallable(functions, 'getSwipeCandidates');
   try {
-    const result = await getSwipeCandidates({ limit, startAfter, cooldownDays });
+    const result = await getSwipeCandidates({
+      limit,
+      startAfter,
+      cooldownDays: cooldownDays ?? 7,
+    });
     const { users, nextCursor } = result.data;
     return success({ users, nextCursor });
   } catch (e) {


### PR DESCRIPTION
## Summary
- update getSwipeCandidates to default to a seven day cooldown and clamp to a minimum of five days
- keep cooldown validation flexible for undefined values while applying the new clamp
- ensure fetchSwipeCandidates passes an explicit seven day cooldown to the callable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d49d9293d8832d9fa1a324530d6abb