### PR TITLE
Update Babel plugins configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel', 'react-native-worklets/plugin'],
+    plugins: ['react-native-worklets/plugin', 'react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- remove the expo-router Babel plugin from the configuration
- ensure the React Native Reanimated plugin is last while keeping the Expo preset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5fa85c924832d85003dc8e7c1b106