### PR TITLE
refactor: migrate cloud functions back to gen2

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,8 @@
     {
       "source": "functions",
       "codebase": "default",
+      "platform": "gcfv2",
+      "runtime": "nodejs18",
       "ignore": [
         "node_modules",
         ".git",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,13 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+const { setGlobalOptions } = require('firebase-functions/v2');
+const { HttpsError, onCall } = require('firebase-functions/v2/https');
+
+setGlobalOptions({
+  region: 'us-central1',
+  memory: '256MiB',
+  timeoutSeconds: 60,
+});
 
 admin.initializeApp();
 
@@ -40,499 +48,450 @@ function mapPublicUserDoc(doc) {
   };
 }
 
-exports.getPublicUsers = functions
-  .region('us-central1')
-  .runWith({ memory: '256MB', timeoutSeconds: 60 })
-  .https.onCall(async (data = {}, context) => {
-    if (enforceAppCheck && !context.app) {
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        'App Check required'
-      );
-    }
-    if (!context.auth) {
-      throw new functions.https.HttpsError('unauthenticated', 'Auth required');
-    }
+exports.getPublicUsers = onCall(async (request) => {
+  const data = request.data ?? {};
 
-    const { limit = 20, startAfter } = data;
+  if (enforceAppCheck && !request.appId) {
+    throw new HttpsError('failed-precondition', 'App Check required');
+  }
 
-    if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'limit must be a positive integer'
-      );
-    }
-    const clampedLimit = Math.min(limit, 100);
-    const fetchLimit = Math.min(clampedLimit + 1, 101);
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Auth required');
+  }
 
-    let startAfterId = null;
-    if (startAfter !== undefined && startAfter !== null) {
-      if (typeof startAfter !== 'string') {
-        throw new functions.https.HttpsError(
-          'invalid-argument',
-          'startAfter must be a string'
-        );
-      }
+  const { limit = 20, startAfter } = data;
 
-      const trimmed = startAfter.trim();
-      if (trimmed.length > 0) {
-        startAfterId = trimmed;
-      }
+  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
+    throw new HttpsError('invalid-argument', 'limit must be a positive integer');
+  }
+
+  const clampedLimit = Math.min(limit, 100);
+  const fetchLimit = Math.min(clampedLimit + 1, 101);
+
+  let startAfterId = null;
+  if (startAfter !== undefined && startAfter !== null) {
+    if (typeof startAfter !== 'string') {
+      throw new HttpsError('invalid-argument', 'startAfter must be a string');
     }
 
-    try {
-      const currentUserId = context.auth.uid;
-
-      let query = admin
-        .firestore()
-        .collection('users')
-        .orderBy(admin.firestore.FieldPath.documentId())
-        .select(...PUBLIC_USER_FIELDS)
-        .limit(fetchLimit);
-
-      if (startAfterId) {
-        query = query.startAfter(startAfterId);
-      }
-
-      const snapshot = await query.get();
-      const filteredDocs = snapshot.docs.filter((doc) => doc.id !== currentUserId);
-      const limitedDocs = filteredDocs.slice(0, clampedLimit);
-      const users = limitedDocs.map(mapPublicUserDoc);
-
-      const hasMore =
-        (snapshot.docs.length === fetchLimit || filteredDocs.length > limitedDocs.length) &&
-        limitedDocs.length > 0;
-      const lastReturnedDoc = limitedDocs[limitedDocs.length - 1];
-      const nextCursor = hasMore && lastReturnedDoc ? lastReturnedDoc.id : null;
-
-      return { users, nextCursor };
-    } catch (err) {
-      console.error('getPublicUsers error', err);
-      if (err instanceof functions.https.HttpsError) {
-        throw err;
-      }
-      throw new functions.https.HttpsError(
-        'internal',
-        'Failed to fetch users'
-      );
+    const trimmed = startAfter.trim();
+    if (trimmed.length > 0) {
+      startAfterId = trimmed;
     }
-  });
+  }
 
-exports.getSwipeCandidates = functions
-  .region('us-central1')
-  .runWith({ memory: '256MB', timeoutSeconds: 60 })
-  .https.onCall(async (data = {}, context) => {
-    if (enforceAppCheck && !context.app) {
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        'App Check required'
-      );
+  try {
+    const currentUserId = request.auth.uid;
+
+    let query = admin
+      .firestore()
+      .collection('users')
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .select(...PUBLIC_USER_FIELDS)
+      .limit(fetchLimit);
+
+    if (startAfterId) {
+      query = query.startAfter(startAfterId);
     }
 
-    if (!context.auth) {
-      throw new functions.https.HttpsError('unauthenticated', 'Auth required');
+    const snapshot = await query.get();
+    const filteredDocs = snapshot.docs.filter((doc) => doc.id !== currentUserId);
+    const limitedDocs = filteredDocs.slice(0, clampedLimit);
+    const users = limitedDocs.map(mapPublicUserDoc);
+
+    const hasMore =
+      (snapshot.docs.length === fetchLimit || filteredDocs.length > limitedDocs.length) &&
+      limitedDocs.length > 0;
+    const lastReturnedDoc = limitedDocs[limitedDocs.length - 1];
+    const nextCursor = hasMore && lastReturnedDoc ? lastReturnedDoc.id : null;
+
+    return { users, nextCursor };
+  } catch (err) {
+    console.error('getPublicUsers error', err);
+    if (err instanceof HttpsError) {
+      throw err;
+    }
+    throw new HttpsError('internal', 'Failed to fetch users');
+  }
+});
+
+exports.getSwipeCandidates = onCall(async (request) => {
+  const data = request.data ?? {};
+
+  if (enforceAppCheck && !request.appId) {
+    throw new HttpsError('failed-precondition', 'App Check required');
+  }
+
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Auth required');
+  }
+
+  const { limit = 20, startAfter, cooldownDays } = data;
+
+  if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
+    throw new HttpsError('invalid-argument', 'limit must be a positive integer');
+  }
+
+  if (
+    cooldownDays !== undefined &&
+    (typeof cooldownDays !== 'number' || Number.isNaN(cooldownDays) || cooldownDays < 0)
+  ) {
+    throw new HttpsError('invalid-argument', 'cooldownDays must be a non-negative number');
+  }
+
+  const clampedLimit = Math.min(limit, 100);
+  const fetchLimit = Math.min(clampedLimit + 1, 101);
+  const cd = Math.max(5, cooldownDays ?? 7);
+  const cooldownMillis = cd * 24 * 60 * 60 * 1000;
+
+  let startAfterId = null;
+  if (startAfter !== undefined && startAfter !== null) {
+    if (typeof startAfter !== 'string') {
+      throw new HttpsError('invalid-argument', 'startAfter must be a string');
     }
 
-    const { limit = 20, startAfter, cooldownDays } = data;
-
-    if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'limit must be a positive integer'
-      );
+    const trimmed = startAfter.trim();
+    if (trimmed.length > 0) {
+      startAfterId = trimmed;
     }
+  }
 
-    if (
-      cooldownDays !== undefined &&
-      (typeof cooldownDays !== 'number' || Number.isNaN(cooldownDays) || cooldownDays < 0)
-    ) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'cooldownDays must be a non-negative number'
-      );
-    }
-
-    const clampedLimit = Math.min(limit, 100);
-    const fetchLimit = Math.min(clampedLimit + 1, 101);
-    const cd = Math.max(5, cooldownDays ?? 7);
-    const cooldownMillis = cd * 24 * 60 * 60 * 1000;
-
-    let startAfterId = null;
-    if (startAfter !== undefined && startAfter !== null) {
-      if (typeof startAfter !== 'string') {
-        throw new functions.https.HttpsError(
-          'invalid-argument',
-          'startAfter must be a string'
-        );
-      }
-
-      const trimmed = startAfter.trim();
-      if (trimmed.length > 0) {
-        startAfterId = trimmed;
-      }
-    }
-
-    try {
-      const db = admin.firestore();
-      const currentUserId = context.auth.uid;
-      const excludedIds = new Set([currentUserId]);
-      const swipeMap = new Map();
-
-      const [swipesSnapshot, matchesSnapshot] = await Promise.all([
-        db.collection('swipes').where('from', '==', currentUserId).get(),
-        db.collection('matches').where('users', 'array-contains', currentUserId).get(),
-      ]);
-
-      swipesSnapshot.forEach((doc) => {
-        const data = doc.data() || {};
-        const toUserId = data.to;
-        if (typeof toUserId === 'string' && toUserId) {
-          swipeMap.set(toUserId, {
-            liked: data.liked,
-            createdAt: data.createdAt ?? null,
-          });
-        }
-      });
-
-      matchesSnapshot.forEach((doc) => {
-        const users = doc.get('users');
-        if (Array.isArray(users)) {
-          users.forEach((uid) => {
-            if (typeof uid === 'string' && uid !== currentUserId) {
-              excludedIds.add(uid);
-            }
-          });
-        }
-      });
-
-      const baseQuery = db
-        .collection('users')
-        .orderBy(admin.firestore.FieldPath.documentId())
-        .select(...PUBLIC_USER_FIELDS)
-        .limit(fetchLimit);
-
-      const maxScans = Math.min(fetchLimit * 5, 500);
-      const users = [];
-      let totalScanned = 0;
-      let cursor = startAfterId ?? null;
-      let lastScannedDocId = cursor;
-      let morePagesAvailable = false;
-
-      while (users.length < clampedLimit && totalScanned < maxScans) {
-        let pageQuery = baseQuery;
-        if (cursor) {
-          pageQuery = pageQuery.startAfter(cursor);
-        }
-
-        const snapshot = await pageQuery.get();
-
-        if (snapshot.empty) {
-          if (cursor) {
-            lastScannedDocId = cursor;
-          }
-          morePagesAvailable = false;
-          break;
-        }
-
-        totalScanned += snapshot.docs.length;
-
-        const lastDoc = snapshot.docs[snapshot.docs.length - 1];
-        if (lastDoc) {
-          lastScannedDocId = lastDoc.id;
-        }
-
-        const filteredDocs = snapshot.docs.filter((doc) => {
-          const candidateId = doc.id;
-          if (excludedIds.has(candidateId)) {
-            return false;
-          }
-
-          const swipeInfo = swipeMap.get(candidateId);
-
-          if (!swipeInfo) {
-            return true;
-          }
-
-          if (swipeInfo.liked === true) {
-            return false;
-          }
-
-          if (swipeInfo.liked === false) {
-            const { createdAt } = swipeInfo;
-            let createdAtDate = null;
-
-            if (createdAt && typeof createdAt.toDate === 'function') {
-              createdAtDate = createdAt.toDate();
-            } else if (createdAt instanceof Date) {
-              createdAtDate = createdAt;
-            }
-
-            if (!createdAtDate) {
-              return false;
-            }
-
-            const elapsed = Date.now() - createdAtDate.getTime();
-
-            if (elapsed < cooldownMillis) {
-              return false;
-            }
-          }
-
-          return true;
-        });
-        const usersBefore = users.length;
-        for (const doc of filteredDocs) {
-          if (users.length >= clampedLimit) {
-            break;
-          }
-          users.push(mapPublicUserDoc(doc));
-        }
-        const addedFromPage = users.length - usersBefore;
-
-        const pageHasMore = snapshot.docs.length === fetchLimit;
-        const hasExtraFiltered = filteredDocs.length > addedFromPage;
-
-        if (users.length >= clampedLimit) {
-          morePagesAvailable = pageHasMore || hasExtraFiltered;
-          break;
-        }
-
-        if (totalScanned >= maxScans) {
-          morePagesAvailable = pageHasMore;
-          break;
-        }
-
-        if (!pageHasMore) {
-          morePagesAvailable = hasExtraFiltered;
-          break;
-        }
-
-        cursor = lastScannedDocId;
-      }
-
-      const nextCursor =
-        morePagesAvailable && lastScannedDocId ? lastScannedDocId : null;
-
-      return { users, nextCursor };
-    } catch (err) {
-      console.error('getSwipeCandidates error', err);
-      if (err instanceof functions.https.HttpsError) {
-        throw err;
-      }
-
-      throw new functions.https.HttpsError(
-        'internal',
-        'Failed to fetch swipe candidates'
-      );
-    }
-  });
-
-exports.likeUser = functions
-  .region('us-central1')
-  .runWith({ memory: '256MB', timeoutSeconds: 60 })
-  .https.onCall(async (data = {}, context) => {
-    if (enforceAppCheck && !context.app) {
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        'App Check required'
-      );
-    }
-
-    if (!context.auth) {
-      throw new functions.https.HttpsError('unauthenticated', 'Auth required');
-    }
-
-    const { targetUserId, liked } = data || {};
-
-    if (typeof targetUserId !== 'string' || targetUserId.trim().length === 0) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'targetUserId must be a non-empty string'
-      );
-    }
-
-    if (typeof liked !== 'boolean') {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'liked must be a boolean'
-      );
-    }
-
+  try {
     const db = admin.firestore();
-    const fromUserId = context.auth.uid;
-    const toUserId = targetUserId.trim();
+    const currentUserId = request.auth.uid;
+    const excludedIds = new Set([currentUserId]);
+    const swipeMap = new Map();
 
-    if (fromUserId === toUserId) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'Users cannot like themselves'
-      );
+    const [swipesSnapshot, matchesSnapshot] = await Promise.all([
+      db.collection('swipes').where('from', '==', currentUserId).get(),
+      db.collection('matches').where('users', 'array-contains', currentUserId).get(),
+    ]);
+
+    swipesSnapshot.forEach((doc) => {
+      const swipeData = doc.data() || {};
+      const toUserId = swipeData.to;
+      if (typeof toUserId === 'string' && toUserId) {
+        swipeMap.set(toUserId, {
+          liked: swipeData.liked,
+          createdAt: swipeData.createdAt ?? null,
+        });
+      }
+    });
+
+    matchesSnapshot.forEach((doc) => {
+      const users = doc.get('users');
+      if (Array.isArray(users)) {
+        users.forEach((uid) => {
+          if (typeof uid === 'string' && uid !== currentUserId) {
+            excludedIds.add(uid);
+          }
+        });
+      }
+    });
+
+    const baseQuery = db
+      .collection('users')
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .select(...PUBLIC_USER_FIELDS)
+      .limit(fetchLimit);
+
+    const maxScans = Math.min(fetchLimit * 5, 500);
+    const users = [];
+    let totalScanned = 0;
+    let cursor = startAfterId ?? null;
+    let lastScannedDocId = cursor;
+    let morePagesAvailable = false;
+
+    while (users.length < clampedLimit && totalScanned < maxScans) {
+      let pageQuery = baseQuery;
+      if (cursor) {
+        pageQuery = pageQuery.startAfter(cursor);
+      }
+
+      const snapshot = await pageQuery.get();
+
+      if (snapshot.empty) {
+        if (cursor) {
+          lastScannedDocId = cursor;
+        }
+        morePagesAvailable = false;
+        break;
+      }
+
+      totalScanned += snapshot.docs.length;
+
+      const lastDoc = snapshot.docs[snapshot.docs.length - 1];
+      if (lastDoc) {
+        lastScannedDocId = lastDoc.id;
+      }
+
+      const filteredDocs = snapshot.docs.filter((doc) => {
+        const candidateId = doc.id;
+        if (excludedIds.has(candidateId)) {
+          return false;
+        }
+
+        const swipeInfo = swipeMap.get(candidateId);
+
+        if (!swipeInfo) {
+          return true;
+        }
+
+        if (swipeInfo.liked === true) {
+          return false;
+        }
+
+        if (swipeInfo.liked === false) {
+          const { createdAt } = swipeInfo;
+          let createdAtDate = null;
+
+          if (createdAt && typeof createdAt.toDate === 'function') {
+            createdAtDate = createdAt.toDate();
+          } else if (createdAt instanceof Date) {
+            createdAtDate = createdAt;
+          }
+
+          if (!createdAtDate) {
+            return false;
+          }
+
+          const elapsed = Date.now() - createdAtDate.getTime();
+
+          if (elapsed < cooldownMillis) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+      const usersBefore = users.length;
+      for (const doc of filteredDocs) {
+        if (users.length >= clampedLimit) {
+          break;
+        }
+        users.push(mapPublicUserDoc(doc));
+      }
+      const addedFromPage = users.length - usersBefore;
+
+      const pageHasMore = snapshot.docs.length === fetchLimit;
+      const hasExtraFiltered = filteredDocs.length > addedFromPage;
+
+      if (users.length >= clampedLimit) {
+        morePagesAvailable = pageHasMore || hasExtraFiltered;
+        break;
+      }
+
+      if (totalScanned >= maxScans) {
+        morePagesAvailable = pageHasMore;
+        break;
+      }
+
+      if (!pageHasMore) {
+        morePagesAvailable = hasExtraFiltered;
+        break;
+      }
+
+      cursor = lastScannedDocId;
     }
 
-    const swipeRef = db
-      .collection('swipes')
-      .doc(`${fromUserId}_${toUserId}`);
-    const reciprocalSwipeRef = db
-      .collection('swipes')
-      .doc(`${toUserId}_${fromUserId}`);
-    const [firstUser, secondUser] = [fromUserId, toUserId].sort();
-    const matchRef = db
-      .collection('matches')
-      .doc(`${firstUser}_${secondUser}`);
-    const fromUserRef = db.collection('users').doc(fromUserId);
-    const toUserRef = db.collection('users').doc(toUserId);
+    const nextCursor = morePagesAvailable && lastScannedDocId ? lastScannedDocId : null;
 
-    try {
-      const match = await db.runTransaction(async (transaction) => {
-        const [
-          swipeDoc,
-          reciprocalSwipeDoc,
-          existingMatchDoc,
-          fromUserDoc,
-          toUserDoc,
-        ] = await Promise.all([
-          transaction.get(swipeRef),
-          transaction.get(reciprocalSwipeRef),
-          transaction.get(matchRef),
-          transaction.get(fromUserRef),
-          transaction.get(toUserRef),
-        ]);
-        const swipeData = { from: fromUserId, to: toUserId, liked };
-        if (swipeDoc.exists) {
-          const updates = { ...swipeData };
-          // Reset cooldown window on every pass
-          if (liked === false) {
-            updates.createdAt = admin.firestore.FieldValue.serverTimestamp();
-          }
-          transaction.set(swipeRef, updates, { merge: true });
-        } else {
-          transaction.set(swipeRef, {
-            ...swipeData,
-            createdAt: admin.firestore.FieldValue.serverTimestamp(),
-          });
+    return { users, nextCursor };
+  } catch (err) {
+    console.error('getSwipeCandidates error', err);
+    if (err instanceof HttpsError) {
+      throw err;
+    }
+
+    throw new HttpsError('internal', 'Failed to fetch swipe candidates');
+  }
+});
+
+exports.likeUser = onCall(async (request) => {
+  const data = request.data ?? {};
+
+  if (enforceAppCheck && !request.appId) {
+    throw new HttpsError('failed-precondition', 'App Check required');
+  }
+
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Auth required');
+  }
+
+  const { targetUserId, liked } = data || {};
+
+  if (typeof targetUserId !== 'string' || targetUserId.trim().length === 0) {
+    throw new HttpsError(
+      'invalid-argument',
+      'targetUserId must be a non-empty string'
+    );
+  }
+
+  if (typeof liked !== 'boolean') {
+    throw new HttpsError('invalid-argument', 'liked must be a boolean');
+  }
+
+  const db = admin.firestore();
+  const fromUserId = request.auth.uid;
+  const toUserId = targetUserId.trim();
+
+  if (fromUserId === toUserId) {
+    throw new HttpsError('invalid-argument', 'Users cannot like themselves');
+  }
+
+  const swipeRef = db
+    .collection('swipes')
+    .doc(`${fromUserId}_${toUserId}`);
+  const reciprocalSwipeRef = db
+    .collection('swipes')
+    .doc(`${toUserId}_${fromUserId}`);
+  const [firstUser, secondUser] = [fromUserId, toUserId].sort();
+  const matchRef = db
+    .collection('matches')
+    .doc(`${firstUser}_${secondUser}`);
+  const fromUserRef = db.collection('users').doc(fromUserId);
+  const toUserRef = db.collection('users').doc(toUserId);
+
+  try {
+    const match = await db.runTransaction(async (transaction) => {
+      const [
+        swipeDoc,
+        reciprocalSwipeDoc,
+        existingMatchDoc,
+        fromUserDoc,
+        toUserDoc,
+      ] = await Promise.all([
+        transaction.get(swipeRef),
+        transaction.get(reciprocalSwipeRef),
+        transaction.get(matchRef),
+        transaction.get(fromUserRef),
+        transaction.get(toUserRef),
+      ]);
+      const swipeData = { from: fromUserId, to: toUserId, liked };
+      if (swipeDoc.exists) {
+        const updates = { ...swipeData };
+        // Reset cooldown window on every pass
+        if (liked === false) {
+          updates.createdAt = admin.firestore.FieldValue.serverTimestamp();
         }
+        transaction.set(swipeRef, updates, { merge: true });
+      } else {
+        transaction.set(swipeRef, {
+          ...swipeData,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      }
 
-        if (!liked) {
-          return false;
-        }
+      if (!liked) {
+        return false;
+      }
 
-        const hasReciprocalLike =
-          reciprocalSwipeDoc.exists &&
-          reciprocalSwipeDoc.get('liked') === true;
+      const hasReciprocalLike =
+        reciprocalSwipeDoc.exists &&
+        reciprocalSwipeDoc.get('liked') === true;
 
-        if (!hasReciprocalLike) {
-          return false;
-        }
+      if (!hasReciprocalLike) {
+        return false;
+      }
 
-        const fromProfileData = fromUserDoc.exists ? fromUserDoc.data() : {};
-        const toProfileData = toUserDoc.exists ? toUserDoc.data() : {};
+      const fromProfileData = fromUserDoc.exists ? fromUserDoc.data() : {};
+      const toProfileData = toUserDoc.exists ? toUserDoc.data() : {};
 
-        let createdMatch = false;
+      let createdMatch = false;
 
-        if (!existingMatchDoc.exists) {
-          transaction.set(matchRef, {
-            users: [firstUser, secondUser],
-            matchedAt: admin.firestore.FieldValue.serverTimestamp(),
-          });
-          createdMatch = true;
-        }
+      if (!existingMatchDoc.exists) {
+        transaction.set(matchRef, {
+          users: [firstUser, secondUser],
+          matchedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+        createdMatch = true;
+      }
 
-        transaction.set(
-          matchRef,
-          {
-            profiles: {
-              [fromUserId]: {
-                name: fromProfileData?.name ?? '',
-                photoURL: fromProfileData?.photoURL ?? null,
-              },
-              [toUserId]: {
-                name: toProfileData?.name ?? '',
-                photoURL: toProfileData?.photoURL ?? null,
-              },
+      transaction.set(
+        matchRef,
+        {
+          profiles: {
+            [fromUserId]: {
+              name: fromProfileData?.name ?? '',
+              photoURL: fromProfileData?.photoURL ?? null,
+            },
+            [toUserId]: {
+              name: toProfileData?.name ?? '',
+              photoURL: toProfileData?.photoURL ?? null,
             },
           },
-          { merge: true }
-        );
+        },
+        { merge: true }
+      );
 
-        return createdMatch;
-      });
-
-      return { match };
-    } catch (err) {
-      console.error('likeUser error', err);
-      if (err instanceof functions.https.HttpsError) {
-        throw err;
-      }
-      throw new functions.https.HttpsError('internal', 'Failed to process like');
+      return createdMatch;
+    });
+    return { match };
+  } catch (err) {
+    console.error('likeUser error', err);
+    if (err instanceof HttpsError) {
+      throw err;
     }
-  });
+    throw new HttpsError('internal', 'Failed to process like');
+  }
+});
 
-exports.sendMessage = functions
-  .region('us-central1')
-  .runWith({ memory: '256MB', timeoutSeconds: 60 })
-  .https.onCall(async (data = {}, context) => {
-    if (enforceAppCheck && !context.app) {
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        'App Check required'
+exports.sendMessage = onCall(async (request) => {
+  const data = request.data ?? {};
+
+  if (enforceAppCheck && !request.appId) {
+    throw new HttpsError('failed-precondition', 'App Check required');
+  }
+
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Auth required');
+  }
+
+  const { matchId, content } = data || {};
+
+  if (typeof matchId !== 'string' || matchId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'matchId must be a non-empty string');
+  }
+
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'content must be a non-empty string');
+  }
+
+  const db = admin.firestore();
+  const uid = request.auth.uid;
+  const trimmedMatchId = matchId.trim();
+
+  try {
+    const matchRef = db.collection('matches').doc(trimmedMatchId);
+    const matchDoc = await matchRef.get();
+
+    if (!matchDoc.exists) {
+      throw new HttpsError('not-found', 'Match not found');
+    }
+
+    const users = matchDoc.get('users');
+    if (!Array.isArray(users) || !users.includes(uid)) {
+      throw new HttpsError(
+        'permission-denied',
+        'User is not part of the match'
       );
     }
 
-    if (!context.auth) {
-      throw new functions.https.HttpsError('unauthenticated', 'Auth required');
+    const messagesRef = matchRef.collection('messages');
+    await messagesRef.add({
+      senderId: uid,
+      content: content.trim(),
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    return { success: true };
+  } catch (err) {
+    console.error('sendMessage error', err);
+    if (err instanceof HttpsError) {
+      throw err;
     }
 
-    const { matchId, content } = data || {};
-
-    if (typeof matchId !== 'string' || matchId.trim().length === 0) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'matchId must be a non-empty string'
-      );
-    }
-
-    if (typeof content !== 'string' || content.trim().length === 0) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'content must be a non-empty string'
-      );
-    }
-
-    const db = admin.firestore();
-    const uid = context.auth.uid;
-    const trimmedMatchId = matchId.trim();
-
-    try {
-      const matchRef = db.collection('matches').doc(trimmedMatchId);
-      const matchDoc = await matchRef.get();
-
-      if (!matchDoc.exists) {
-        throw new functions.https.HttpsError('not-found', 'Match not found');
-      }
-
-      const users = matchDoc.get('users');
-      if (!Array.isArray(users) || !users.includes(uid)) {
-        throw new functions.https.HttpsError(
-          'permission-denied',
-          'User is not part of the match'
-        );
-      }
-
-      const messagesRef = matchRef.collection('messages');
-      await messagesRef.add({
-        senderId: uid,
-        content: content.trim(),
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      });
-
-      return { success: true };
-    } catch (err) {
-      console.error('sendMessage error', err);
-      if (err instanceof functions.https.HttpsError) {
-        throw err;
-      }
-
-      throw new functions.https.HttpsError('internal', 'Failed to send message');
-    }
-  });
+    throw new HttpsError('internal', 'Failed to send message');
+  }
+});
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,13 +9,13 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "main": "index.js",
   "type": "commonjs",
   "dependencies": {
-    "firebase-admin": "^11.11.1",
-    "firebase-functions": "^3.25.0"
+    "firebase-admin": "^12.6.0",
+    "firebase-functions": "^4.4.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
## Summary
- convert callable functions to the firebase-functions v2 onCall APIs and configure global runtime options
- enforce updated auth/app checks while preserving existing business logic for matches, messaging, and discovery
- update Cloud Functions runtime configuration to Node.js 18/gcfv2 in package.json and firebase.json

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddcb7c6cdc832d9553c0cd211c71be