### PR TITLE
Adjust login navigation and email verification copy

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -11,8 +11,17 @@ const SplashScreen = () => {
   useEffect(() => {
     const redirect = async () => {
       const result = await ensureAuth();
-      // ✅ Redirect to a concrete tab route (home) instead of just "/(tabs)"
-      router.replace(result.ok ? '/(tabs)/home/homeScreen' : '/auth/loginScreen');
+      if (result.ok) {
+        router.replace('/(tabs)/home/homeScreen');
+        return;
+      }
+
+      if (result.error?.code === 'email-not-verified') {
+        router.replace('/auth/verificationScreen');
+        return;
+      }
+
+      router.replace('/auth/loginScreen');
     };
 
     redirect();

--- a/services/authService.js
+++ b/services/authService.js
@@ -23,5 +23,29 @@ export async function ensureAuth() {
   if (!user) {
     return failure('no-auth');
   }
-  return success({ user });
+
+  try {
+    await user.reload();
+  } catch (error) {
+    console.warn('Failed to reload auth user.', error);
+  }
+
+  const refreshedUser = auth.currentUser;
+  if (!refreshedUser) {
+    return failure('no-auth');
+  }
+
+  if (!refreshedUser.emailVerified) {
+    return failure('email-not-verified');
+  }
+
+  return success({ user: refreshedUser });
+}
+
+export function normalizeEmail(email) {
+  if (typeof email !== 'string') {
+    return '';
+  }
+
+  return email.trim().toLowerCase();
 }


### PR DESCRIPTION
## Summary
- remove the inline registration path from the login screen and normalize navigation to the register flow
- route successful sign-ins with navigation.replace to block returning to auth screens
- simplify verification to an email-link flow with refreshed copy and cooldown-only resend control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e34f8fb01c832d846f15df8aefa33c