### PR TITLE
Add email verification tracking documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ To learn more about developing your project with Expo, look at the following res
 - [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
 - [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
 
+## Firestore data model
+
+### `emailVerifications` (top-level collection)
+
+Each document is stored at `emailVerifications/{uid}` and mirrors a single Firebase Auth user. New users get a document in `pending` status during registration.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | string enum | One of `pending`, `sent`, `verified`, or `failed`. Client writes are limited to the initial `pending` state. |
+| `createdAt` | timestamp | Server timestamp captured when the document is first created. |
+| `updatedAt` | timestamp | Last server-side update time. |
+| `tokenHash` | string or null | Hash of the email verification token managed by backend jobs. |
+| `lastError` | map or null | Optional error metadata with keys `code`, `message`, and `at` (a timestamp) recorded by backend processes when email delivery fails. |
+
+> **Note:** Aside from the initial `pending` document created by the client, all subsequent mutations (status transitions, timestamps, token hashing, error recording) must be performed by trusted server code using the Admin SDK or a service account with the `admin` custom claim. Corresponding Firestore security rules enforce this separation of responsibilities.
+
 ## Join the community
 
 Join our community of developers creating universal apps.

--- a/app/auth/registerScreen.js
+++ b/app/auth/registerScreen.js
@@ -5,7 +5,7 @@ import { Feather, MaterialIcons } from '@expo/vector-icons';
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation } from 'expo-router';
 import { createUserWithEmailAndPassword, sendEmailVerification, updateProfile } from 'firebase/auth';
-import { doc, setDoc } from 'firebase/firestore';
+import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
 import { auth, db } from '../../firebaseConfig';
 import { normalizeEmail } from '../../services/authService';
 import { useUser } from '../../context/userContext';
@@ -69,6 +69,15 @@ const RegisterScreen = () => {
             }
 
             await setDoc(userRef, profileData, { merge: true });
+
+            const verificationRef = doc(db, 'emailVerifications', user.uid);
+            await setDoc(verificationRef, {
+                status: 'pending',
+                createdAt: serverTimestamp(),
+                updatedAt: serverTimestamp(),
+                tokenHash: null,
+                lastError: null,
+            });
 
             setProfile({ uid: user.uid, ...profileData });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -48,6 +48,23 @@ service cloud.firestore {
                     isValidUserUpdate(request.resource.data, uid);
     }
 
+    match /emailVerifications/{uid} {
+      allow get: if request.auth != null && request.auth.uid == uid;
+
+      allow create: if request.auth != null &&
+                    request.auth.uid == uid &&
+                    request.resource.data.keys().hasOnly([
+                      'status', 'createdAt', 'updatedAt', 'tokenHash', 'lastError'
+                    ]) &&
+                    request.resource.data.status == 'pending' &&
+                    request.resource.data.createdAt == request.time &&
+                    request.resource.data.updatedAt == request.time &&
+                    (!request.resource.data.keys().hasAny(['tokenHash']) || request.resource.data.tokenHash == null) &&
+                    (!request.resource.data.keys().hasAny(['lastError']) || request.resource.data.lastError == null);
+
+      allow update, delete: if request.auth != null && request.auth.token.admin == true;
+    }
+
     function isValidContactMessage(data) {
       return data.keys().hasOnly(['name', 'email', 'message', 'createdAt']) &&
              data.name is string && data.name.size() > 0 && data.name.size() <= 100 &&


### PR DESCRIPTION
## Summary
- create email verification document alongside user profile onboarding
- describe the emailVerifications collection schema in the README for future reference
- restrict Firestore rules so only trusted code can update verification documents beyond initial creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cf1b4734832daea9a59fbb1699f2