### PR TITLE
Remove verification link from client responses

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -882,7 +882,6 @@ exports.requestEmailVerification = onCall(async (request) => {
       emailVerified: false,
       cooldownSeconds,
       cooldown: postCooldown,
-      additional: { link: sendResult.link },
     });
   } catch (err) {
     console.error('requestEmailVerification error', uid, err);

--- a/services/emailVerificationService.js
+++ b/services/emailVerificationService.js
@@ -79,7 +79,6 @@ function normalizeVerificationData(data = {}) {
     canRequest: Boolean(data.canRequest),
     lastError: normalizeErrorPayload(data.lastError),
     lastDelivery: normalizeDeliveryPayload(data.lastDelivery),
-    link: typeof data.link === 'string' ? data.link : null,
   };
 }
 


### PR DESCRIPTION
## Summary
- stop including the verification link in the requestEmailVerification callable response
- update the client email verification service to drop the deprecated link field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e45e7ac090832d99833c3c701ccf54