### PR TITLE
Ensure user documents store uid and phone number

### DIFF
--- a/app/auth/loginScreen.js
+++ b/app/auth/loginScreen.js
@@ -59,13 +59,38 @@ const LoginScreen = () => {
             const userRef = doc(db, 'users', uid);
             const userDoc = await getDoc(userRef);
 
+            const trimmedDisplayName = displayName ? displayName.trim() : '';
+            const trimmedPhoneNumber = phoneNumber ? phoneNumber.trim() : '';
+            const baseProfile = { uid, email: authEmail };
+
             let profileData;
             if (!userDoc.exists()) {
-                profileData = { uid, name: displayName || '', email: authEmail };
-                await setDoc(userRef, { name: displayName || '', email: authEmail }, { merge: true });
+                const newProfileData = { ...baseProfile };
+
+                if (trimmedDisplayName) {
+                    newProfileData.name = trimmedDisplayName;
+                }
+
+                if (trimmedPhoneNumber) {
+                    newProfileData.phoneNumber = trimmedPhoneNumber;
+                }
+
+                await setDoc(userRef, newProfileData, { merge: true });
+                profileData = newProfileData;
             } else {
-                profileData = { ...userDoc.data(), uid, email: authEmail };
-                await setDoc(userRef, { email: authEmail }, { merge: true });
+                const existingData = userDoc.data() || {};
+                const updates = { ...baseProfile };
+
+                if (trimmedPhoneNumber) {
+                    updates.phoneNumber = trimmedPhoneNumber;
+                }
+
+                if (trimmedDisplayName && !existingData.name) {
+                    updates.name = trimmedDisplayName;
+                }
+
+                await setDoc(userRef, updates, { merge: true });
+                profileData = { ...existingData, ...updates };
             }
 
             setProfile(profileData);

--- a/app/auth/registerScreen.js
+++ b/app/auth/registerScreen.js
@@ -59,6 +59,7 @@ const RegisterScreen = () => {
 
             const userRef = doc(db, 'users', user.uid);
             const profileData = {
+                uid: user.uid,
                 email: normalizedEmail,
             };
 
@@ -81,7 +82,7 @@ const RegisterScreen = () => {
                 lastError: null,
             });
 
-            setProfile({ uid: user.uid, ...profileData });
+            setProfile({ ...profileData });
 
             let verificationParams = { reason: 'account-created' };
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
     function hasOnlyAllowedUserKeys(data) {
       return data.keys().hasOnly([
         'uid', 'name', 'email', 'age', 'gender', 'photoURL', 'bio',
-        'image', 'address', 'distance', 'profession', 'isFavorite'
+        'image', 'address', 'distance', 'profession', 'isFavorite', 'phoneNumber'
       ]);
     }
 
@@ -14,7 +14,8 @@ service cloud.firestore {
       return data.keys().hasAll(['uid', 'email']) &&
              data.uid == uid &&
              data.email is string &&
-             (!data.keys().hasAny(['name']) || data.name is string);
+             (!data.keys().hasAny(['name']) || data.name is string) &&
+             (!data.keys().hasAny(['phoneNumber']) || data.phoneNumber is string);
     }
 
     function isValidUserUpdate(data, uid) {
@@ -30,7 +31,8 @@ service cloud.firestore {
              (!data.keys().hasAny(['address']) || data.address is string) &&
              (!data.keys().hasAny(['distance']) || (data.distance is number && data.distance >= 0)) &&
              (!data.keys().hasAny(['profession']) || data.profession is string) &&
-             (!data.keys().hasAny(['isFavorite']) || data.isFavorite is bool);
+             (!data.keys().hasAny(['isFavorite']) || data.isFavorite is bool) &&
+             (!data.keys().hasAny(['phoneNumber']) || data.phoneNumber is string);
     }
 
     match /users/{uid} {


### PR DESCRIPTION
## Summary
- include the authenticated user uid when persisting new profiles and keep optional phone numbers trimmed on registration and login
- update the login flow to backfill uid, optional phone numbers, and missing names while preserving existing profile data
- allow the phoneNumber field in Firestore security rules for both create and update operations

## Testing
- `npx firebase deploy --only firestore:rules` *(fails: npm 403 forbidden in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45e7a4738832db5cddddd899a1af8