### PR TITLE
Add dev skip option to verification screen

### DIFF
--- a/app/auth/verificationScreen.js
+++ b/app/auth/verificationScreen.js
@@ -148,6 +148,14 @@ const VerificationScreen = () => {
         }
     }, [cooldown, isLoading, verification]);
 
+    const handleSkipDev = useCallback(() => {
+        if (!__DEV__) {
+            return;
+        }
+
+        router.replace('/(tabs)/home/homeScreen');
+    }, [router]);
+
     const statusMessage = useMemo(() => {
         if (verification?.emailVerified) {
             return 'Your email has been verified. Redirecting you to the app...';
@@ -199,6 +207,7 @@ const VerificationScreen = () => {
                     {verificationInfo()}
                     {resendInfo()}
                     {verifyButton()}
+                    {skipDevButton()}
                     {statusFeedback()}
                 </ScrollView>
                 {loadingDialog()}
@@ -254,6 +263,28 @@ const VerificationScreen = () => {
             >
                 <Text style={{ ...Fonts.whiteColor20Medium }}>
                     {isLoading ? 'Verifying...' : 'Verify'}
+                </Text>
+            </TouchableOpacity>
+        )
+    }
+
+    function skipDevButton() {
+        if (!__DEV__) {
+            return null;
+        }
+
+        return (
+            <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={handleSkipDev}
+                style={{
+                    ...styles.buttonStyle,
+                    backgroundColor: Colors.bgColor,
+                    marginTop: -Sizes.fixPadding,
+                }}
+            >
+                <Text style={{ ...Fonts.blackColor17Medium }}>
+                    Skip verification (dev)
                 </Text>
             </TouchableOpacity>
         )


### PR DESCRIPTION
## Summary
- add a development-only skip button to the verification screen
- route the skip button directly to the home tabs screen when pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e494072200832d971ccf16dc302258