### PR TITLE
Convert image source helper to JavaScript

### DIFF
--- a/app/(tabs)/chat/chatScreen.js
+++ b/app/(tabs)/chat/chatScreen.js
@@ -6,8 +6,7 @@ import { useNavigation } from 'expo-router';
 import { useUser } from '../../../context/userContext';
 import { auth, db } from '../../../firebaseConfig';
 import { collection, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore';
-
-const defaultUserImage = require('../../../assets/images/users/user1.png');
+import { getUserImageSource } from '../../../utils/imageSource';
 
 const ChatScreen = () => {
 
@@ -246,26 +245,6 @@ const ChatScreen = () => {
             </View>
         )
     }
-}
-
-function getUserImageSource(user) {
-    if (!user) {
-        return defaultUserImage;
-    }
-
-    if (typeof user.image === 'number') {
-        return user.image;
-    }
-
-    if (user.image) {
-        return { uri: user.image };
-    }
-
-    if (user.photoURL) {
-        return { uri: user.photoURL };
-    }
-
-    return defaultUserImage;
 }
 
 function formatTimestamp(timestamp) {

--- a/app/(tabs)/home/homeScreen.js
+++ b/app/(tabs)/home/homeScreen.js
@@ -15,6 +15,7 @@ import { useNavigation } from 'expo-router'
 import TinderCard from 'react-tinder-card'
 import { LinearGradient } from 'expo-linear-gradient'
 import { fetchSwipeCandidates, likeUser } from '../../../services/userService'
+import { getUserImageSource } from '../../../utils/imageSource'
 
 const HomeScreen = () => {
 
@@ -24,8 +25,6 @@ const HomeScreen = () => {
     const [search, setsearch] = useState('');
     const searchFieldRef = useRef(null);
     const seenStateRef = useRef({ key: null, set: new Set() })
-    const defaultUserImage = require('../../../assets/images/users/user1.png');
-
     const getTodayKey = () => {
         const today = new Date()
         const isoDate = today.toISOString().split('T')[0]
@@ -158,26 +157,6 @@ const HomeScreen = () => {
                 return item
             }
         }));
-    }
-
-    function getUserImageSource(user) {
-        if (!user) {
-            return defaultUserImage;
-        }
-
-        if (typeof user.image === 'number') {
-            return user.image;
-        }
-
-        if (user.image) {
-            return { uri: user.image };
-        }
-
-        if (user.photoURL) {
-            return { uri: user.photoURL };
-        }
-
-        return defaultUserImage;
     }
 
     function usersInfo() {

--- a/utils/imageSource.js
+++ b/utils/imageSource.js
@@ -1,0 +1,35 @@
+const defaultUserImage = require('../assets/images/users/user1.png');
+
+export const getUserImageSource = (user, fallbackImage) => {
+    const defaultImage = fallbackImage ?? defaultUserImage;
+
+    if (!user) {
+        return defaultImage;
+    }
+
+    const { image, photoURL } = user;
+
+    if (typeof image === 'number') {
+        return image;
+    }
+
+    if (image && typeof image === 'object') {
+        return image;
+    }
+
+    if (typeof image === 'string' && image.trim().length > 0) {
+        return { uri: image };
+    }
+
+    if (typeof photoURL === 'string' && photoURL.trim().length > 0) {
+        return { uri: photoURL };
+    }
+
+    if (photoURL && typeof photoURL === 'object') {
+        return photoURL;
+    }
+
+    return defaultImage;
+};
+
+export const defaultUserImageSource = defaultUserImage;


### PR DESCRIPTION
## Summary
- extract a shared `getUserImageSource` helper for resolving local and remote profile images
- update the home and chat tabs to consume the new helper and keep existing functionality
- convert the shared image source helper to plain JavaScript while retaining existing behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e49f997bd0832dab9906ea29f73dc7