### PR TITLE
Refactor email verification to use Firebase Auth SDK

### DIFF
--- a/app/auth/loginScreen.js
+++ b/app/auth/loginScreen.js
@@ -10,7 +10,6 @@ import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth, db } from '../../firebaseConfig';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { normalizeEmail } from '../../services/authService';
-import { checkEmailVerificationStatus } from '../../services/emailVerificationService';
 
 const LoginScreen = () => {
 
@@ -101,32 +100,8 @@ const LoginScreen = () => {
                 Alert.alert('Success', 'Logged in successfully');
                 navigation.replace('(tabs)');
             } else {
-                const statusResult = await checkEmailVerificationStatus();
-
-                let status = 'pending';
-                let cooldown = 0;
-                let resendAllowed = false;
-                let message = 'Please verify your email address to continue.';
-
-                if (statusResult.ok) {
-                    const verification = statusResult.data;
-                    status = verification?.status ?? status;
-                    cooldown = verification?.cooldownRemainingSeconds ?? cooldown;
-                    resendAllowed = Boolean(verification?.canRequest && cooldown <= 0);
-
-                    if (verification?.status === 'failed' || verification?.lastDelivery?.failed) {
-                        message = 'We had trouble sending your verification email. You can try resending from the verification screen.';
-                    } else if (cooldown > 0) {
-                        message = 'A verification email was recently sent. You can request another once the cooldown ends.';
-                    } else if (verification?.status === 'sent') {
-                        message = 'We sent a verification email. Please check your inbox to verify your account.';
-                    }
-                } else {
-                    message = statusResult.error?.message || 'We were unable to check your verification status. Please try again later.';
-                }
-
-                Alert.alert('Verify Email', message);
-                navigation.replace('auth/verificationScreen', { status, cooldown, resendAllowed, message });
+                Alert.alert('Verify Email', 'Please verify your email address to continue.');
+                navigation.replace('auth/verificationScreen', { reason: 'email-verification-required' });
                 return;
             }
         } catch (error) {

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,7 +1,6 @@
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from '../firebaseConfig';
 import { success, failure } from './result';
-import { checkEmailVerificationStatus, deriveVerificationCode } from './emailVerificationService';
 
 let authInitPromise;
 
@@ -37,52 +36,28 @@ export async function ensureAuth(options = {}) {
     return failure('no-auth');
   }
 
+  const verifiedPayload = includeVerificationStatus
+    ? { user: refreshedUser, verification: { emailVerified: true } }
+    : { user: refreshedUser };
+
   if (refreshedUser.emailVerified) {
-    return success({ user: refreshedUser });
-  }
-
-  if (!includeVerificationStatus) {
-    return allowUnverified
-      ? success({ user: refreshedUser })
-      : failure('email-verification-required');
-  }
-
-  const statusResult = await checkEmailVerificationStatus();
-
-  if (!statusResult.ok) {
-    if (allowUnverified) {
-      return success({ user: refreshedUser, verification: null });
-    }
-
-    const error = statusResult.error;
-    return failure(
-      error?.code || 'email-verification-status-failed',
-      error?.message || 'We could not verify your email status. Please try again.',
-      error?.details,
-    );
-  }
-
-  const verification = statusResult.data;
-
-  if (verification.emailVerified) {
-    return success({ user: auth.currentUser ?? refreshedUser });
+    return success(verifiedPayload);
   }
 
   if (allowUnverified) {
-    return success({ user: refreshedUser, verification });
+    const unverifiedPayload = includeVerificationStatus
+      ? { user: refreshedUser, verification: { emailVerified: false } }
+      : { user: refreshedUser };
+    return success(unverifiedPayload);
   }
 
-  const code = deriveVerificationCode(verification);
+  const details = includeVerificationStatus ? { verification: { emailVerified: false } } : undefined;
 
-  let message = 'Please verify your email address to continue.';
-  if (code === 'email-verification-cooldown') {
-    message = 'Please check your inbox. You can request another verification email once the cooldown ends.';
-  } else if (code === 'email-verification-delivery-failed') {
-    message =
-      'We had trouble sending a verification email to your address. Please try resending it from the verification screen.';
-  }
-
-  return failure(code, message, { verification });
+  return failure(
+    'email-verification-required',
+    'Please verify your email address to continue.',
+    details,
+  );
 }
 
 export function normalizeEmail(email) {

--- a/services/emailVerificationService.js
+++ b/services/emailVerificationService.js
@@ -1,155 +1,18 @@
-import { httpsCallable } from 'firebase/functions';
-import { functions } from '../firebaseConfig';
+import { sendEmailVerification } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
 import { success, failure } from './result';
 
-function normalizeTimestamp(value) {
-  if (!value) {
-    return null;
+export async function sendVerificationEmail(user = auth.currentUser) {
+  if (!user) {
+    return failure('no-auth', 'Please sign in again to continue.');
   }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-
-  if (typeof value.toDate === 'function') {
-    return value.toDate().toISOString();
-  }
-
-  if (typeof value.toMillis === 'function') {
-    return new Date(value.toMillis()).toISOString();
-  }
-
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return new Date(value).toISOString();
-  }
-
-  return null;
-}
-
-function toPositiveInteger(value, defaultValue = 0) {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return defaultValue;
-  }
-
-  const rounded = Math.round(value);
-  return rounded > 0 ? rounded : defaultValue;
-}
-
-function normalizeErrorPayload(error) {
-  if (!error) {
-    return null;
-  }
-
-  return {
-    code: typeof error.code === 'string' ? error.code : 'unknown',
-    message: typeof error.message === 'string' ? error.message : '',
-    at: normalizeTimestamp(error.at),
-  };
-}
-
-function normalizeDeliveryPayload(delivery) {
-  if (!delivery) {
-    return null;
-  }
-
-  return {
-    source: delivery.source ?? null,
-    generatedAt: normalizeTimestamp(delivery.generatedAt),
-    failed: Boolean(delivery.failed),
-  };
-}
-
-function normalizeVerificationData(data = {}) {
-  return {
-    status: typeof data.status === 'string' ? data.status : 'pending',
-    email: typeof data.email === 'string' ? data.email : null,
-    emailVerified: Boolean(data.emailVerified),
-    createdAt: normalizeTimestamp(data.createdAt),
-    updatedAt: normalizeTimestamp(data.updatedAt),
-    verifiedAt: normalizeTimestamp(data.verifiedAt),
-    lastRequestedAt: normalizeTimestamp(data.lastRequestedAt),
-    lastSentAt: normalizeTimestamp(data.lastSentAt),
-    cooldownSeconds: toPositiveInteger(data.cooldownSeconds, null),
-    cooldownRemainingSeconds: toPositiveInteger(data.cooldownRemainingSeconds, 0),
-    cooldownEndsAt: normalizeTimestamp(data.cooldownEndsAt),
-    canRequest: Boolean(data.canRequest),
-    lastError: normalizeErrorPayload(data.lastError),
-    lastDelivery: normalizeDeliveryPayload(data.lastDelivery),
-  };
-}
-
-function mapCallableError(error, fallbackCode, fallbackMessage) {
-  const rawCode = typeof error?.code === 'string' ? error.code : 'unknown';
-  const code = rawCode.startsWith('functions/') ? rawCode.replace('functions/', '') : rawCode;
-
-  switch (code) {
-    case 'unauthenticated':
-      return failure('no-auth', 'Please sign in again to continue.');
-    case 'failed-precondition':
-      return failure(
-        'email-verification-precondition',
-        error?.message || 'We were unable to send a verification email because your account is missing information.'
-      );
-    case 'invalid-argument':
-      return failure('email-verification-invalid-request', error?.message || 'The verification request was invalid.');
-    case 'permission-denied':
-      return failure('email-verification-permission-denied', error?.message || 'You do not have permission to perform this action.');
-    default:
-      console.error('Email verification callable failed', error);
-      return failure(fallbackCode, fallbackMessage);
-  }
-}
-
-export async function requestEmailVerification(options = {}) {
-  const callable = httpsCallable(functions, 'requestEmailVerification');
 
   try {
-    const result = await callable(options);
-    return success(normalizeVerificationData(result.data));
+    await sendEmailVerification(user);
+    return success();
   } catch (error) {
-    return mapCallableError(
-      error,
-      'email-verification-request-failed',
-      'We were unable to send a verification email. Please try again later.'
-    );
+    console.warn('Failed to send verification email.', error);
+    const message = error?.message || 'We were unable to send a verification email. Please try again later.';
+    return failure('email-verification-send-failed', message);
   }
-}
-
-export async function checkEmailVerificationStatus(options = {}) {
-  const callable = httpsCallable(functions, 'checkEmailVerificationStatus');
-
-  try {
-    const result = await callable(options);
-    return success(normalizeVerificationData(result.data));
-  } catch (error) {
-    return mapCallableError(
-      error,
-      'email-verification-status-failed',
-      'We were unable to check your verification status. Please try again later.'
-    );
-  }
-}
-
-export function deriveVerificationCode(verification) {
-  if (!verification) {
-    return 'email-verification-required';
-  }
-
-  if (verification.emailVerified) {
-    return 'email-verified';
-  }
-
-  if (verification.status === 'failed' || verification.lastDelivery?.failed) {
-    return 'email-verification-delivery-failed';
-  }
-
-  if (!verification.canRequest && verification.cooldownRemainingSeconds > 0) {
-    return 'email-verification-cooldown';
-  }
-
-  return 'email-verification-pending';
 }


### PR DESCRIPTION
## Summary
- replace callable-based email verification flows with Firebase Auth's sendEmailVerification
- poll auth.currentUser for verification status and manage resend cooldown locally
- simplify auth service logic to rely solely on Firebase Auth state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4b4d6288c832d8d4c58fa731cb5f6