### PR TITLE
Disable client usage of email verification callables on Spark

### DIFF
--- a/app/auth/registerScreen.js
+++ b/app/auth/registerScreen.js
@@ -5,7 +5,7 @@ import { Feather, MaterialIcons } from '@expo/vector-icons';
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation, useRouter } from 'expo-router';
 import { createUserWithEmailAndPassword, sendEmailVerification, updateProfile } from 'firebase/auth';
-import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { doc, setDoc } from 'firebase/firestore';
 import { auth, db } from '../../firebaseConfig';
 import { normalizeEmail } from '../../services/authService';
 import { useUser } from '../../context/userContext';
@@ -71,15 +71,6 @@ const RegisterScreen = () => {
             }
 
             await setDoc(userRef, profileData, { merge: true });
-
-            const verificationRef = doc(db, 'emailVerifications', user.uid);
-            await setDoc(verificationRef, {
-                status: 'pending',
-                createdAt: serverTimestamp(),
-                updatedAt: serverTimestamp(),
-                tokenHash: null,
-                lastError: null,
-            });
 
             setProfile({ ...profileData });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -725,6 +725,8 @@ exports.sendMessage = onCall(async (request) => {
   }
 });
 
+// Deprecated: callable email verification requests are disabled on Spark.
+// TODO(blaze-migration): Re-enable when moving to Blaze.
 exports.requestEmailVerification = onCall(async (request) => {
   assertAppCheck(request);
 
@@ -893,6 +895,8 @@ exports.requestEmailVerification = onCall(async (request) => {
   }
 });
 
+// Deprecated: callable email verification status checks are disabled on Spark.
+// TODO(blaze-migration): Re-enable when moving to Blaze.
 exports.checkEmailVerificationStatus = onCall(async (request) => {
   assertAppCheck(request);
 


### PR DESCRIPTION
## Summary
- mark the email verification callables as deprecated until the Blaze plan migration
- remove the client write to emailVerifications and update docs to reflect optional backend flows
- refresh manual validation guidance to focus on Firebase Auth polling on Spark

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4b91d9c6c832d98f1b241a6a49c92