### PR TITLE
Remove Firestore email verification metadata write

### DIFF
--- a/app/auth/registerScreen.js
+++ b/app/auth/registerScreen.js
@@ -5,7 +5,7 @@ import { Feather, MaterialIcons } from '@expo/vector-icons';
 import MyStatusBar from '../../components/myStatusBar';
 import { useNavigation, useRouter } from 'expo-router';
 import { createUserWithEmailAndPassword, sendEmailVerification, updateProfile } from 'firebase/auth';
-import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { doc, setDoc } from 'firebase/firestore';
 import { auth, db } from '../../firebaseConfig';
 import { normalizeEmail } from '../../services/authService';
 import { useUser } from '../../context/userContext';
@@ -71,15 +71,6 @@ const RegisterScreen = () => {
             }
 
             await setDoc(userRef, profileData, { merge: true });
-
-            const verificationRef = doc(db, 'emailVerifications', user.uid);
-            await setDoc(verificationRef, {
-                status: 'pending',
-                createdAt: serverTimestamp(),
-                updatedAt: serverTimestamp(),
-                tokenHash: null,
-                lastError: null,
-            });
 
             setProfile({ ...profileData });
 


### PR DESCRIPTION
## Summary
- stop persisting email verification metadata when creating a user
- remove the unused `serverTimestamp` import from the registration screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4b92764fc832d8c18c4d4e6147b5e